### PR TITLE
enableEdgeToEdgeを削除

### DIFF
--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/MainActivity.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/MainActivity.kt
@@ -3,7 +3,6 @@ package jp.ac.mayoi.maigocompass
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -16,7 +15,6 @@ import jp.ac.mayoi.maigocompass.ui.theme.MaigoCompassTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContent {
             MaigoCompassTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->
@koae0522 と EdgeToEdge 対応はしないということを決めたので、MainActivityからenableEdgeToEdgeを削除した

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=81154287

### 変更内容

<!-- 詳細な変更内容を書く -->

- `:phone:app` の `MainActivity` から `enableEdgeToEdge` を削除