### PR TITLE
maigobuttonを作った

### DIFF
--- a/phone/core/util/build.gradle.kts
+++ b/phone/core/util/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 dependencies {
 
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.bundles.composeKit)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
+++ b/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
@@ -3,20 +3,22 @@ package jp.ac.mayoi.core.util
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun MaigoButton(
+    modifier: Modifier = Modifier,
     onClick: () -> Unit,
     colors: ButtonColors = ButtonDefaults.buttonColors(), //後からアプリ側で設定したやつに置き換える
-    modifier: Modifier = Modifier,
     enabled: Boolean = true,
     content: @Composable RowScope.() -> Unit,
 ) {
@@ -25,8 +27,14 @@ fun MaigoButton(
         colors = colors,
         modifier = modifier
             .padding(horizontal = 16.dp, vertical = 16.dp)
-            .defaultMinSize(minWidth = 120.dp, minHeight = 60.dp),
+            .defaultMinSize(minWidth = 120.dp, minHeight = 60.dp)
+            .shadow(
+                elevation = 8.dp,
+                shape = RoundedCornerShape(40.dp),
+            ),
         enabled = enabled,
+        shape = RoundedCornerShape(40.dp),
+        elevation = ButtonDefaults.elevatedButtonElevation(defaultElevation = 16.dp), // elevationを強調
         content = content,
     )
 }

--- a/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
+++ b/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
@@ -1,7 +1,6 @@
 package jp.ac.mayoi.core.util
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
@@ -19,7 +18,7 @@ fun MaigoButton(
     colors: ButtonColors = ButtonDefaults.buttonColors(), //後からアプリ側で設定したやつに置き換える
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    content: @Composable BoxScope.() -> Unit,
+    content: @Composable RowScope.() -> Unit,
 ) {
     Button(
         onClick = onClick,
@@ -28,12 +27,8 @@ fun MaigoButton(
             .padding(horizontal = 16.dp, vertical = 16.dp)
             .defaultMinSize(minWidth = 120.dp, minHeight = 60.dp),
         enabled = enabled,
-    ) {
-
-        Box() {
-            content()
-        }
-    }
+        content = content,
+    )
 }
 
 @Preview(showBackground = true)
@@ -42,7 +37,6 @@ fun ButtonPreview() {
     MaigoButton(
         onClick = { },
         content = {
-
             Text("ボタン")
         }
     )

--- a/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
+++ b/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
@@ -16,10 +16,10 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun MaigoButton(
-    modifier: Modifier = Modifier,
     onClick: () -> Unit,
-    colors: ButtonColors = ButtonDefaults.buttonColors(), //後からアプリ側で設定したやつに置き換える
     enabled: Boolean = true,
+    colors: ButtonColors = ButtonDefaults.buttonColors(), //後からアプリ側で設定したやつに置き換える
+    modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit,
 ) {
     Button(

--- a/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
+++ b/phone/core/util/src/main/java/jp/ac/mayoi/core/util/Buttons.kt
@@ -1,2 +1,49 @@
 package jp.ac.mayoi.core.util
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MaigoButton(
+    onClick: () -> Unit,
+    colors: ButtonColors = ButtonDefaults.buttonColors(), //後からアプリ側で設定したやつに置き換える
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        colors = colors,
+        modifier = modifier
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+            .defaultMinSize(minWidth = 120.dp, minHeight = 60.dp),
+        enabled = enabled,
+    ) {
+
+        Box() {
+            content()
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ButtonPreview() {
+    MaigoButton(
+        onClick = { },
+        content = {
+
+            Text("ボタン")
+        }
+    )
+}


### PR DESCRIPTION
## 概要
FigmaのDesign Templateに合わせて、`phone` 側で利用するMaigoButtonを作成した。
<!-- ざっくりと変更内容や必要な情報を書く -->

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=81853047
