### PR TITLE
ランキング画面のボタン要素の作成

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
+
 }

--- a/phone/features/ranking/build.gradle.kts
+++ b/phone/features/ranking/build.gradle.kts
@@ -30,6 +30,8 @@ android {
 }
 
 dependencies {
+    implementation(project(":phone:core:resource"))
+
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.composeKit)
     implementation(libs.bundles.coil)

--- a/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
+++ b/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
@@ -5,42 +5,68 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.resource.colorAccent
+import jp.ac.mayoi.core.resource.colorAccentSecondary
+import jp.ac.mayoi.core.resource.colorBackgroundPrimary
+import jp.ac.mayoi.core.resource.colorTextCaption
 
 @Composable
 fun CustomToggleButtons() {
-    val buttonLabels = listOf("エリア名")
+    val buttonLabels = listOf("エリア名", "とてもながいエリア名", "さらに長いエリア名が続きます")
     var selectedButtonIndex by remember { mutableStateOf(0) }
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically
     ) {
         buttonLabels.forEachIndexed { index, label ->
-            Button(
-                onClick = { selectedButtonIndex = index },
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = if (selectedButtonIndex == index) Color(0xFFFF8080) else Color.White,
-                    contentColor = if (selectedButtonIndex == index) Color.White else Color.Gray
-                ),
-                shape = RoundedCornerShape(50),
-                border = BorderStroke(2.dp, Color.Cyan),
-                modifier = Modifier.padding(horizontal = 4.dp)
-            ) {
-                Text(text = label, style = TextStyle(fontSize = 14.sp))
-            }
+            RankingButtonChip(
+                label = label,
+                isSelected = selectedButtonIndex == index,
+                onClick = { selectedButtonIndex = index }
+            )
         }
+    }
+}
+
+@Composable
+fun RankingButtonChip(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = if (isSelected) colorAccent else colorBackgroundPrimary,
+            contentColor = if (isSelected) colorBackgroundPrimary else colorTextCaption
+        ),
+        shape = RoundedCornerShape(16.dp),
+        border = if (isSelected) null else BorderStroke(1.dp, colorAccentSecondary),
+        modifier = Modifier
+            .padding(horizontal = 4.dp)
+            .height(48.dp)
+            .wrapContentWidth()
+    ) {
+        Text(text = label, style = TextStyle(fontSize = 14.sp))
     }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun CustomToggleButtonsPreview() {
-    CustomToggleButtons()
+    MaigoCompassTheme {
+        CustomToggleButtons()
+    }
 }

--- a/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
+++ b/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
@@ -1,0 +1,46 @@
+package jp.ac.mayoi.ranking
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.shape.RoundedCornerShape
+
+@Composable
+fun CustomToggleButtons() {
+    val buttonLabels = listOf("エリア名")
+    var selectedButtonIndex by remember { mutableStateOf(0) }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        buttonLabels.forEachIndexed { index, label ->
+            Button(
+                onClick = { selectedButtonIndex = index },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (selectedButtonIndex == index) Color(0xFFFF8080) else Color.White,
+                    contentColor = if (selectedButtonIndex == index) Color.White else Color.Gray
+                ),
+                shape = RoundedCornerShape(50),
+                border = BorderStroke(2.dp, Color.Cyan),
+                modifier = Modifier.padding(horizontal = 4.dp)
+            ) {
+                Text(text = label, style = TextStyle(fontSize = 14.sp))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CustomToggleButtonsPreview() {
+    CustomToggleButtons()
+}

--- a/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
+++ b/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
@@ -19,7 +19,7 @@ import jp.ac.mayoi.core.resource.colorTextCaption
 
 
 @Composable
-public fun RankingButtonChip(
+fun RankingButtonChip(
     label: String,
     isSelected: Boolean,
     onClick: () -> Unit

--- a/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
+++ b/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -19,7 +18,7 @@ import jp.ac.mayoi.core.resource.colorBackgroundPrimary
 import jp.ac.mayoi.core.resource.colorTextCaption
 
 @Composable
-fun CustomToggleButtons() {
+private fun CustomToggleButtons() {
     val buttonLabels = listOf("エリア名", "とてもながいエリア名", "さらに長いエリア名が続きます")
     var selectedButtonIndex by remember { mutableStateOf(0) }
 
@@ -41,7 +40,7 @@ fun CustomToggleButtons() {
 }
 
 @Composable
-fun RankingButtonChip(
+private fun RankingButtonChip(
     label: String,
     isSelected: Boolean,
     onClick: () -> Unit
@@ -50,23 +49,40 @@ fun RankingButtonChip(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(
             containerColor = if (isSelected) colorAccent else colorBackgroundPrimary,
-            contentColor = if (isSelected) colorBackgroundPrimary else colorTextCaption
         ),
         shape = RoundedCornerShape(16.dp),
         border = if (isSelected) null else BorderStroke(1.dp, colorAccentSecondary),
         modifier = Modifier
-            .padding(horizontal = 4.dp)
-            .height(48.dp)
-            .wrapContentWidth()
+            .height(48.dp) // ボタンの幅を文字の長さに応じて調整
     ) {
-        Text(text = label, style = TextStyle(fontSize = 14.sp))
+        Text(
+            text = label,
+            fontSize = 14.sp,
+            color = if (isSelected) colorBackgroundPrimary else colorTextCaption
+        )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun CustomToggleButtonsPreview() {
+private fun CustomToggleButtonsPreview() {
     MaigoCompassTheme {
         CustomToggleButtons()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SelectedRankingButtonChipPreview() {
+    MaigoCompassTheme {
+        RankingButtonChip(label = "エリア名", isSelected = true, onClick = {})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UnselectedRankingButtonChipPreview() {
+    MaigoCompassTheme {
+        RankingButtonChip(label = "エリア名", isSelected = false, onClick = {})
     }
 }

--- a/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
+++ b/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/Button.kt
@@ -29,7 +29,7 @@ fun RankingButtonChip(
         colors = ButtonDefaults.buttonColors(
             containerColor = if (isSelected) colorAccent else colorBackgroundPrimary,
         ),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(32.dp),
         border = if (isSelected) null else BorderStroke(1.dp, colorAccentSecondary),
         modifier = Modifier
             .height(48.dp)
@@ -46,8 +46,6 @@ fun RankingButtonChip(
 @Composable
 private fun CustomToggleButtonsPreview() {
     MaigoCompassTheme {
-
-
         val buttonLabels = listOf("エリア名", "とてもながいエリア名", "さらに長いエリア名が続きます")
         var selectedButtonIndex by remember { mutableStateOf(0) }
 
@@ -64,7 +62,6 @@ private fun CustomToggleButtonsPreview() {
             }
         }
     }
-
 }
 
 

--- a/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/RankingButton.kt
+++ b/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/RankingButton.kt
@@ -53,7 +53,6 @@ private fun CustomToggleButtonsPreview() {
 
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically
         ) {
             itemsIndexed(buttonLabels) { index, label ->

--- a/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/RankingButton.kt
+++ b/phone/features/ranking/src/main/java/jp/ac/mayoi/ranking/RankingButton.kt
@@ -9,38 +9,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.resource.colorAccent
 import jp.ac.mayoi.core.resource.colorAccentSecondary
 import jp.ac.mayoi.core.resource.colorBackgroundPrimary
 import jp.ac.mayoi.core.resource.colorTextCaption
 
-@Composable
-private fun CustomToggleButtons() {
-    val buttonLabels = listOf("エリア名", "とてもながいエリア名", "さらに長いエリア名が続きます")
-    var selectedButtonIndex by remember { mutableStateOf(0) }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.Start,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        buttonLabels.forEachIndexed { index, label ->
-            RankingButtonChip(
-                label = label,
-                isSelected = selectedButtonIndex == index,
-                onClick = { selectedButtonIndex = index }
-            )
-        }
-    }
-}
 
 @Composable
-private fun RankingButtonChip(
+public fun RankingButtonChip(
     label: String,
     isSelected: Boolean,
     onClick: () -> Unit
@@ -53,7 +32,7 @@ private fun RankingButtonChip(
         shape = RoundedCornerShape(16.dp),
         border = if (isSelected) null else BorderStroke(1.dp, colorAccentSecondary),
         modifier = Modifier
-            .height(48.dp) // ボタンの幅を文字の長さに応じて調整
+            .height(48.dp)
     ) {
         Text(
             text = label,
@@ -67,9 +46,28 @@ private fun RankingButtonChip(
 @Composable
 private fun CustomToggleButtonsPreview() {
     MaigoCompassTheme {
-        CustomToggleButtons()
+
+
+        val buttonLabels = listOf("エリア名", "とてもながいエリア名", "さらに長いエリア名が続きます")
+        var selectedButtonIndex by remember { mutableStateOf(0) }
+
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            itemsIndexed(buttonLabels) { index, label ->
+                RankingButtonChip(
+                    label = label,
+                    isSelected = selectedButtonIndex == index,
+                    onClick = { selectedButtonIndex = index }
+                )
+            }
+        }
     }
+
 }
+
 
 @Preview(showBackground = true)
 @Composable


### PR DESCRIPTION
## 概要

ランキング画面のボタン要素の作成、それに伴いButton.ktの作成。

2024/10/23 追記
Button.ktをRankingButton.ktに名前変更しました。

### 関係するタスク

https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=81905765

### 変更内容

phone\features\ranking\src\main\java\jp\ac\mayoi\rankingにButton.ktを新規に作成。
Button.ktではランキング画面のボタン要素の作成をしている。

## テスト

ボタンが2個以上の時、ボタンの選択状態によって問題なくボタンの色が変更されるかを確認した。
line17)val buttonLabels = listOf("エリア名")　※PR時
listOfの部分を複数個の項目に変えてボタンが複数表示されるようにして、ボタン色の切り替えができるように確認した。

ex.) val buttonLabels = listOf("エリア名","エリア名","名前がちょっと長いエリア名")


## 画像
![image](https://github.com/user-attachments/assets/e5dc09d9-8070-44ca-86bb-d19befb24d35)
