### PR TITLE
MaigoButtonで作成したボタンの色をテンプレートの色に合わせる

### DIFF
--- a/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Colors.kt
+++ b/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Colors.kt
@@ -1,10 +1,11 @@
 package jp.ac.mayoi.wear.core.resource
 
 import androidx.compose.runtime.Composable
-import jp.ac.mayoi.common.resource.buttonColorsDefaultCommon
+import androidx.wear.compose.material.ButtonDefaults
 import jp.ac.mayoi.common.resource.colorAccentCommon
 import jp.ac.mayoi.common.resource.colorAccentSecondaryCommon
 import jp.ac.mayoi.common.resource.colorBackgroundPrimaryDarkCommon
+import jp.ac.mayoi.common.resource.colorBackgroundPrimaryLightCommon
 import jp.ac.mayoi.common.resource.colorBackgroundSecondaryDarkCommon
 import jp.ac.mayoi.common.resource.colorTextCaptionCommon
 import jp.ac.mayoi.common.resource.colorTextMainDarkCommon
@@ -17,8 +18,13 @@ val colorTextMain = colorTextMainDarkCommon
 val colorTextCaption = colorTextCaptionCommon
 val colorAccent = colorAccentCommon
 val colorAccentSecondary = colorAccentSecondaryCommon
+val colorButtonTextPrimary = colorBackgroundPrimaryLightCommon
 
 // ButtonColors
 
 val buttonColorsDefault
-    @Composable get() = buttonColorsDefaultCommon
+    @Composable get() =
+        ButtonDefaults.primaryButtonColors(
+            backgroundColor = colorAccent,
+            contentColor = colorButtonTextPrimary
+        )

--- a/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/MaigoBotton.kt
+++ b/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/MaigoBotton.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonColors
-import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Text
 import androidx.wear.tooling.preview.devices.WearDevices
 
@@ -22,7 +21,7 @@ import androidx.wear.tooling.preview.devices.WearDevices
 fun MaigoButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    colors: ButtonColors = ButtonDefaults.primaryButtonColors(),
+    colors: ButtonColors = buttonColorsDefault,
     enabled: Boolean = true,
     shape: Shape = RoundedCornerShape(32.dp),
     content: @Composable BoxScope.() -> Unit,
@@ -44,11 +43,13 @@ fun MaigoButton(
                     horizontal = 16.dp,
                     vertical = 16.dp
                 )
+
         ) {
             content()
         }
     }
 }
+
 
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable

--- a/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/MaigoBotton.kt
+++ b/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/MaigoBotton.kt
@@ -43,13 +43,11 @@ fun MaigoButton(
                     horizontal = 16.dp,
                     vertical = 16.dp
                 )
-
         ) {
             content()
         }
     }
 }
-
 
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable


### PR DESCRIPTION
## 概要
Maigobuttonで作成したボタンの色をデザイン案であるテンプレートの色に合わせる
<!-- ざっくりと変更内容や必要な情報を書く -->

### 関係するタスク
https://github.com/orgs/mayoi-design/projects/1/views/1?filterQuery=priority%3A%22%E3%81%99%E3%81%90%E3%82%84%E3%82%8B%22&pane=issue&itemId=81849717
<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

### 変更内容
デフォルトで設定されていたボタンの色をテンプレートで指定されている色に変更する
<!-- 詳細な変更内容を書く -->

