### PR TITLE
旅行中画面の近くにスポットがない場合の中心画面の作成

### DIFF
--- a/phone/features/traveling/build.gradle.kts
+++ b/phone/features/traveling/build.gradle.kts
@@ -22,8 +22,10 @@ android {
 }
 
 dependencies {
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.activity.compose)
+    implementation(project(":phone:core:util"))
+    implementation(project(":phone:core:resource"))
+    implementation(libs.bundles.composeKit)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -18,7 +18,9 @@ import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
-internal fun SpotEmptyScreen(onSubmitSpot: () -> Unit) {
+internal fun SpotEmptyScreen(
+    onSubmitSpotButtonClick: () -> Unit
+) {
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -27,7 +29,7 @@ internal fun SpotEmptyScreen(onSubmitSpot: () -> Unit) {
     ) {
         Text(
             fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center,
+            //textAlign = TextAlign.Center,
             text = "この近くにはまだスポットがないようです",
             fontSize = 16.sp,
             lineHeight = 24.sp
@@ -35,12 +37,14 @@ internal fun SpotEmptyScreen(onSubmitSpot: () -> Unit) {
         Spacer(modifier = Modifier.size(24.dp))
         Text(
             fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
             text = "あなたが最初のスポットを\n登録してみませんか？",
-            fontSize = 16.sp
+            fontSize = 16.sp,
+            lineHeight = 24.sp
         )
         Spacer(modifier = Modifier.size(24.dp))
         MaigoButton(
-            onClick = { },
+            onClick = onSubmitSpotButtonClick,
             modifier = Modifier
                 .width(240.dp),
         ) {
@@ -58,7 +62,7 @@ internal fun SpotEmptyScreen(onSubmitSpot: () -> Unit) {
 fun TripPreview() {
     MaigoCompassTheme {
         SpotEmptyScreen(
-            onSubmitSpot = { }
+            onSubmitSpotButtonClick = { }
         )
     }
 }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -1,15 +1,13 @@
 package jp.ac.mayoi.traveling
-
-//import androidx.compose.foundation.layout.FlowColumnScopeInstance.align
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -20,45 +18,38 @@ import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
-fun Trip(modifier: Modifier = Modifier) {
+internal fun SpotEmptyScreen(onSubmitSpot: () -> Unit) {
     Column(
         verticalArrangement = Arrangement.Center,
-        modifier = modifier
-            .width(450.dp)
-            .height(753.dp)
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
     ) {
         Text(
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
             text = "この近くにはまだスポットがないようです",
             fontSize = 16.sp,
-            lineHeight = 24.sp,
-            modifier = Modifier.fillMaxWidth()
+            lineHeight = 24.sp
         )
         Spacer(modifier = Modifier.size(24.dp))
         Text(
             fontWeight = FontWeight.Bold,
             text = "あなたが最初のスポットを\n登録してみませんか？",
-            fontSize = 16.sp,
-            lineHeight = 24.sp,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .align(alignment = androidx.compose.ui.Alignment.CenterHorizontally)
+            fontSize = 16.sp
         )
         Spacer(modifier = Modifier.size(24.dp))
         MaigoButton(
             onClick = { },
             modifier = Modifier
-                .width(240.dp)
-                .align(alignment = androidx.compose.ui.Alignment.CenterHorizontally),
-            content = {
-                Text(
-                    fontWeight = FontWeight.Bold,
-                    text = "スポットを登録",
-                    textAlign = TextAlign.Center,
-                )
-            }
-        )
+                .width(240.dp),
+        ) {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = "スポットを登録",
+                fontSize = 16.sp
+            )
+        }
     }
 }
 
@@ -66,7 +57,8 @@ fun Trip(modifier: Modifier = Modifier) {
 @Composable
 fun TripPreview() {
     MaigoCompassTheme {
-        Trip(
+        SpotEmptyScreen(
+            onSubmitSpot = { }
         )
     }
 }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -1,2 +1,73 @@
 package jp.ac.mayoi.traveling
 
+//import androidx.compose.foundation.layout.FlowColumnScopeInstance.align
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.util.MaigoButton
+
+@Composable
+fun Trip(modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+            .width(450.dp)
+            .height(753.dp)
+    ) {
+        Text(
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            text = "この近くにはまだスポットがないようです",
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.size(24.dp))
+        Text(
+            fontWeight = FontWeight.Bold,
+            text = "あなたが最初のスポットを\n登録してみませんか？",
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .align(alignment = androidx.compose.ui.Alignment.CenterHorizontally)
+        )
+        Spacer(modifier = Modifier.size(24.dp))
+        MaigoButton(
+            onClick = { },
+            modifier = Modifier
+                .width(240.dp)
+                .align(alignment = androidx.compose.ui.Alignment.CenterHorizontally),
+            content = {
+                Text(
+                    fontWeight = FontWeight.Bold,
+                    text = "スポットを登録",
+                    textAlign = TextAlign.Center,
+                )
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TripPreview() {
+    MaigoCompassTheme {
+        Trip(
+        )
+    }
+}
+

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -29,7 +29,6 @@ internal fun SpotEmptyScreen(
     ) {
         Text(
             fontWeight = FontWeight.Bold,
-            //textAlign = TextAlign.Center,
             text = "この近くにはまだスポットがないようです",
             fontSize = 16.sp,
             lineHeight = 24.sp


### PR DESCRIPTION
## 概要

旅行中画面の近くにおすすめスポットがない時に表示する画面の中央部分の作成 

### 関係するタスク

https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=80902595
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

## 画像
<!-- 実装した画面のスクリーンショットを貼りましょう -->
<!-- 必要そうなら変更前後の画像を貼りましょう -->

![image](https://github.com/user-attachments/assets/095c21b2-d97f-4b51-b2e1-bda0d17e8dd6)