### PR TITLE
旅行中断ボタンの作成

### DIFF
--- a/phone/core/resource/src/main/res/values/strings.xml
+++ b/phone/core/resource/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Maigo Compass</string>
+    <string name="traveling_cancel_travel">旅行を中断</string>
 </resources>

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
@@ -6,11 +6,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.resource.StringR
 import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
@@ -25,7 +27,7 @@ fun TripCancelButton(
     ) {
         Text(
             fontWeight = FontWeight.Bold,
-            text = "旅行を中断",
+            text = stringResource(StringR.traveling_cancel_travel),
             fontSize = 16.sp
         )
     }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
@@ -1,0 +1,42 @@
+package jp.ac.mayoi.traveling
+
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.util.MaigoButton
+
+@Composable
+fun TripCancelButton(
+    onTripCancelButtonClick: () -> Unit
+) {
+    MaigoButton(
+        onClick = onTripCancelButtonClick,
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB3261E)),
+        modifier = Modifier
+            .width(200.dp),
+    ) {
+        Text(
+            fontWeight = FontWeight.Bold,
+            text = "旅行を中断",
+            fontSize = 16.sp
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TripCancelPreview() {
+    MaigoCompassTheme {
+        TripCancelButton(
+            onTripCancelButtonClick = { }
+        )
+    }
+}

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
@@ -21,7 +21,7 @@ fun TripCancelButton(
         onClick = onTripCancelButtonClick,
         colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB3261E)),
         modifier = Modifier
-            .width(200.dp),
+            .width(180.dp),
     ) {
         Text(
             fontWeight = FontWeight.Bold,
@@ -33,7 +33,7 @@ fun TripCancelButton(
 
 @Preview(showBackground = true)
 @Composable
-fun TripCancelPreview() {
+private fun TripCancelPreview() {
     MaigoCompassTheme {
         TripCancelButton(
             onTripCancelButtonClick = { }


### PR DESCRIPTION
## 概要

旅行中のすべての画面に適応できる旅行中断ボタンの作成

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

## 画像
![image](https://github.com/user-attachments/assets/53518d15-4e7c-49d7-b407-8e69d445649c)