### PR TITLE
旅行中の近くにスポットがない場合の画面のボトム部分の作成

### DIFF
--- a/phone/core/resource/src/main/res/values/strings.xml
+++ b/phone/core/resource/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <resources>
     <string name="app_name">Maigo Compass</string>
+    <string name="traveling_noNear_spot">この近くにはまだスポットがないようです</string>
+    <string name="traveling_register_firstSpot">あなたが最初のスポットを\n登録してみませんか？</string>
+    <string name="traveling_register_spot">スポットを登録</string>
     <string name="traveling_cancel_travel">旅行を中断</string>
 </resources>

--- a/phone/core/resource/src/main/res/values/strings.xml
+++ b/phone/core/resource/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Maigo Compass</string>
+    <string name="traveling_cancel_travel">旅行を中断</string>
 </resources>

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.resource.StringR
 import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
@@ -32,7 +34,7 @@ internal fun SpotEmptyScreen(
         ) {
             Text(
                 fontWeight = FontWeight.Bold,
-                text = "この近くにはまだスポットがないようです",
+                text = stringResource(StringR.traveling_noNear_spot),
                 fontSize = 16.sp,
                 lineHeight = 24.sp
             )
@@ -40,7 +42,7 @@ internal fun SpotEmptyScreen(
             Text(
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
-                text = "あなたが最初のスポットを\n登録してみませんか？",
+                text = stringResource(StringR.traveling_register_firstSpot),
                 fontSize = 16.sp,
                 lineHeight = 24.sp
             )
@@ -52,7 +54,7 @@ internal fun SpotEmptyScreen(
             ) {
                 Text(
                     fontWeight = FontWeight.Bold,
-                    text = "スポットを登録",
+                    text = stringResource(StringR.traveling_register_spot),
                     fontSize = 16.sp
                 )
             }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -63,7 +63,9 @@ internal fun SpotEmptyScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
         ) {
-            TripCancelButton(onTripCancelButtonClick)
+            TripCancelButton(
+                onTripCancelButtonClick = onTripCancelButtonClick,
+            )
         }
     }
 }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -1,5 +1,6 @@
 package jp.ac.mayoi.traveling
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,49 +20,59 @@ import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
 internal fun SpotEmptyScreen(
-    onSubmitSpotButtonClick: () -> Unit
+    onSubmitSpotButtonClick: () -> Unit,
+    onTripCancelButtonClick: () -> Unit
 ) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
-        Text(
-            fontWeight = FontWeight.Bold,
-            text = "この近くにはまだスポットがないようです",
-            fontSize = 16.sp,
-            lineHeight = 24.sp
-        )
-        Spacer(modifier = Modifier.size(24.dp))
-        Text(
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center,
-            text = "あなたが最初のスポットを\n登録してみませんか？",
-            fontSize = 16.sp,
-            lineHeight = 24.sp
-        )
-        Spacer(modifier = Modifier.size(24.dp))
-        MaigoButton(
-            onClick = onSubmitSpotButtonClick,
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
-                .width(240.dp),
+                .fillMaxSize()
         ) {
             Text(
                 fontWeight = FontWeight.Bold,
-                text = "スポットを登録",
-                fontSize = 16.sp
+                text = "この近くにはまだスポットがないようです",
+                fontSize = 16.sp,
+                lineHeight = 24.sp
             )
+            Spacer(modifier = Modifier.size(24.dp))
+            Text(
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                text = "あなたが最初のスポットを\n登録してみませんか？",
+                fontSize = 16.sp,
+                lineHeight = 24.sp
+            )
+            Spacer(modifier = Modifier.size(24.dp))
+            MaigoButton(
+                onClick = onSubmitSpotButtonClick,
+                modifier = Modifier
+                    .width(240.dp),
+            ) {
+                Text(
+                    fontWeight = FontWeight.Bold,
+                    text = "スポットを登録",
+                    fontSize = 16.sp
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+        ) {
+            TripCancelButton(onTripCancelButtonClick)
         }
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun TripPreview() {
+private fun TripPreview() {
     MaigoCompassTheme {
         SpotEmptyScreen(
-            onSubmitSpotButtonClick = { }
+            onSubmitSpotButtonClick = { },
+            onTripCancelButtonClick = { }
         )
     }
 }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
@@ -6,11 +6,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.resource.StringR
 import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
@@ -25,7 +27,7 @@ fun TripCancelButton(
     ) {
         Text(
             fontWeight = FontWeight.Bold,
-            text = "旅行を中断",
+            text = stringResource(StringR.traveling_cancel_travel),
             fontSize = 16.sp
         )
     }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
@@ -1,0 +1,42 @@
+package jp.ac.mayoi.traveling
+
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.util.MaigoButton
+
+@Composable
+fun TripCancelButton(
+    onTripCancelButtonClick: () -> Unit
+) {
+    MaigoButton(
+        onClick = onTripCancelButtonClick,
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB3261E)),
+        modifier = Modifier
+            .width(200.dp),
+    ) {
+        Text(
+            fontWeight = FontWeight.Bold,
+            text = "旅行を中断",
+            fontSize = 16.sp
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TripCancelPreview() {
+    MaigoCompassTheme {
+        TripCancelButton(
+            onTripCancelButtonClick = { }
+        )
+    }
+}

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TripCancelButton.kt
@@ -21,7 +21,7 @@ fun TripCancelButton(
         onClick = onTripCancelButtonClick,
         colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB3261E)),
         modifier = Modifier
-            .width(200.dp),
+            .width(180.dp),
     ) {
         Text(
             fontWeight = FontWeight.Bold,
@@ -33,7 +33,7 @@ fun TripCancelButton(
 
 @Preview(showBackground = true)
 @Composable
-fun TripCancelPreview() {
+private fun TripCancelPreview() {
     MaigoCompassTheme {
         TripCancelButton(
             onTripCancelButtonClick = { }


### PR DESCRIPTION
## 概要
旅行中の近くにスポットがない場合の画面のボトム部分の作成

<!-- ざっくりと変更内容や必要な情報を書く -->

## 関係するタスク
https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=83888218

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->



<!-- 詳細な変更内容を書く -->


<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

## 画像

![image](https://github.com/user-attachments/assets/41bf879c-5cb2-4227-958a-592be2bc93e9)

<!-- 実装した画面のスクリーンショットを貼りましょう -->
<!-- 必要そうなら変更前後の画像を貼りましょう -->
