### PR TITLE
Watch内の目的地設定画面を実装

### DIFF
--- a/wear/features/waiting/build.gradle.kts
+++ b/wear/features/waiting/build.gradle.kts
@@ -38,6 +38,8 @@ android {
 
 dependencies {
     implementation(libs.androidx.wear.tooling.preview)
+    implementation(project(":wear:core:resource"))
+    implementation(project(":common:resource"))
     debugImplementation(libs.androidx.ui.tooling)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.compose.material)

--- a/wear/features/waiting/build.gradle.kts
+++ b/wear/features/waiting/build.gradle.kts
@@ -37,7 +37,6 @@ android {
 }
 
 dependencies {
-    implementation(project(":common:resource"))
     implementation(project(":wear:core:resource"))
 
     implementation(libs.androidx.wear.tooling.preview)

--- a/wear/features/waiting/build.gradle.kts
+++ b/wear/features/waiting/build.gradle.kts
@@ -37,9 +37,10 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.wear.tooling.preview)
-    implementation(project(":wear:core:resource"))
     implementation(project(":common:resource"))
+    implementation(project(":wear:core:resource"))
+
+    implementation(libs.androidx.wear.tooling.preview)
     debugImplementation(libs.androidx.ui.tooling)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.compose.material)

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
@@ -32,19 +32,19 @@ fun WaitingScreen(
             .fillMaxSize()
     ) {
         Text(
-            modifier = Modifier
-                .padding(bottom = spacingDouble),
             text = "目的地を設定\nしてみましょう",
             fontSize = 13.sp,
             color = colorTextMain,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .padding(bottom = spacingDouble)
         )
         if (isButtonView) {
             MaigoButton(
+                onClick = onSetDestinationButtonClick,
                 modifier = Modifier
                     .height(47.dp)
-                    .width(138.dp),
-                onClick = onSetDestinationButtonClick
+                    .width(138.dp)
             ) {
                 Text(
                     text = "目的地を設定",
@@ -61,7 +61,6 @@ fun WaitingScreen(
                     text = "スマートフォンの操作を\n待機しています…",
                     fontSize = 12.sp,
                     textAlign = TextAlign.Center
-
                 )
             }
         }

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
@@ -2,32 +2,77 @@ package jp.ac.mayoi.wear.features.waiting
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.wear.compose.material.MaterialTheme
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.Text
 import androidx.wear.tooling.preview.devices.WearDevices
-
+import jp.ac.mayoi.common.resource.colorBackgroundPrimaryLightCommon
+import jp.ac.mayoi.wear.core.resource.MaigoButton
 
 @Composable
 fun WaitingScreen() {
+    var isButtonView by remember { mutableStateOf(true) }
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
+            .padding(bottom = 50.dp)
             .fillMaxSize()
     ) {
         Text(
-            text = "ようこそ",
-            color = MaterialTheme.colors.primary,
+            modifier = Modifier
+                .padding(bottom = 10.dp),
+            text = "目的地を設定\nしてみましょう",
+            fontSize = 13.sp,
+            color = colorBackgroundPrimaryLightCommon,
+            textAlign = TextAlign.Center
         )
+        if (isButtonView) {
+            MaigoButton(
+                modifier = Modifier
+                    .padding(top = 95.dp)
+                    .height(47.dp)
+                    .width(138.dp),
+                onClick = {
+                    isButtonView = false
+                }
+            ) {
+                Text(
+                    text = "目的地を設定",
+                    fontSize = 12.sp,
+                    textAlign = TextAlign.Center
+
+                )
+            }
+        } else {
+            Text(
+                text = "スマートフォンの操作を\n待機しています…",
+                fontSize = 12.sp,
+                modifier = Modifier
+                    .padding(top = 90.dp),
+                textAlign = TextAlign.Center
+            )
+        }
+
+
     }
+
 }
 
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
-fun DefaultPreview() {
+private fun DefaultPreview() {
     WaitingScreen()
-
 }
+

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
@@ -1,15 +1,12 @@
 package jp.ac.mayoi.wear.features.waiting
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -28,8 +25,8 @@ fun WaitingScreen(
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
         modifier = Modifier
-            .padding(top = 45.dp)
             .fillMaxSize()
     ) {
         Text(
@@ -45,9 +42,7 @@ fun WaitingScreen(
                 modifier = Modifier
                     .height(47.dp)
                     .width(138.dp),
-                onClick = {
-                    onSetDestinationButtonClick()
-                }
+                onClick = onSetDestinationButtonClick
             ) {
                 Text(
                     text = "目的地を設定",
@@ -65,21 +60,21 @@ fun WaitingScreen(
     }
 }
 
+// ボタンがでないバージョン
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
-fun PreviewButton() {
-    var isButtonView by remember { mutableStateOf(true) }
-    val onSetDestinationButtonClick = {
-        isButtonView = false
-    }
+private fun InitialPreview() {
     WaitingScreen(
-        isButtonView = isButtonView,
-        onSetDestinationButtonClick = onSetDestinationButtonClick
+        isButtonView = true,
+        onSetDestinationButtonClick = {/*なにか処理*/ }
     )
 }
 
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
-private fun DefaultPreview() {
-    PreviewButton()
+private fun SettingPreview() {
+    WaitingScreen(
+        isButtonView = false,
+        onSetDestinationButtonClick = {/*なにか処理*/ }
+    )
 }
-

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
@@ -1,6 +1,7 @@
 package jp.ac.mayoi.wear.features.waiting
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -17,6 +18,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.tooling.preview.devices.WearDevices
 import jp.ac.mayoi.wear.core.resource.MaigoButton
 import jp.ac.mayoi.wear.core.resource.colorTextMain
+import jp.ac.mayoi.wear.core.resource.spacingDouble
 
 @Composable
 fun WaitingScreen(
@@ -31,7 +33,8 @@ fun WaitingScreen(
     ) {
         Text(
             modifier = Modifier
-                .padding(bottom = 10.dp),
+                .padding(bottom = spacingDouble),
+            // .padding(bottom = 10.dp),
             text = "目的地を設定\nしてみましょう",
             fontSize = 13.sp,
             color = colorTextMain,
@@ -51,11 +54,17 @@ fun WaitingScreen(
                 )
             }
         } else {
-            Text(
-                text = "スマートフォンの操作を\n待機しています…",
-                fontSize = 12.sp,
-                textAlign = TextAlign.Center
-            )
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.height(47.dp)
+            ) {
+                Text(
+                    text = "スマートフォンの操作を\n待機しています…",
+                    fontSize = 12.sp,
+                    textAlign = TextAlign.Center
+
+                )
+            }
         }
     }
 }

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
@@ -20,7 +20,6 @@ import androidx.wear.compose.material.Text
 import androidx.wear.tooling.preview.devices.WearDevices
 import jp.ac.mayoi.wear.core.resource.MaigoButton
 import jp.ac.mayoi.wear.core.resource.colorTextMain
-import jp.ac.mayoi.wear.core.resource.textStyleBody
 
 @Composable
 fun WaitingScreen(
@@ -37,7 +36,7 @@ fun WaitingScreen(
             modifier = Modifier
                 .padding(bottom = 10.dp),
             text = "目的地を設定\nしてみましょう",
-            style = textStyleBody,
+            fontSize = 13.sp,
             color = colorTextMain,
             textAlign = TextAlign.Center
         )

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
@@ -34,7 +34,6 @@ fun WaitingScreen(
         Text(
             modifier = Modifier
                 .padding(bottom = spacingDouble),
-            // .padding(bottom = 10.dp),
             text = "目的地を設定\nしてみましょう",
             fontSize = 13.sp,
             color = colorTextMain,
@@ -69,7 +68,7 @@ fun WaitingScreen(
     }
 }
 
-// ボタンがでないバージョン
+// ボタンがないバージョン
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 private fun InitialPreview() {
@@ -79,6 +78,7 @@ private fun InitialPreview() {
     )
 }
 
+// ボタンがあるバージョン
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 private fun SettingPreview() {

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreen.kt
@@ -1,6 +1,6 @@
 package jp.ac.mayoi.wear.features.waiting
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,61 +18,69 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.Text
 import androidx.wear.tooling.preview.devices.WearDevices
-import jp.ac.mayoi.common.resource.colorBackgroundPrimaryLightCommon
 import jp.ac.mayoi.wear.core.resource.MaigoButton
+import jp.ac.mayoi.wear.core.resource.colorTextMain
+import jp.ac.mayoi.wear.core.resource.textStyleBody
 
 @Composable
-fun WaitingScreen() {
-    var isButtonView by remember { mutableStateOf(true) }
-    Box(
-        contentAlignment = Alignment.Center,
+fun WaitingScreen(
+    isButtonView: Boolean,
+    onSetDestinationButtonClick: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
-            .padding(bottom = 50.dp)
+            .padding(top = 45.dp)
             .fillMaxSize()
     ) {
         Text(
             modifier = Modifier
                 .padding(bottom = 10.dp),
             text = "目的地を設定\nしてみましょう",
-            fontSize = 13.sp,
-            color = colorBackgroundPrimaryLightCommon,
+            style = textStyleBody,
+            color = colorTextMain,
             textAlign = TextAlign.Center
         )
         if (isButtonView) {
             MaigoButton(
                 modifier = Modifier
-                    .padding(top = 95.dp)
                     .height(47.dp)
                     .width(138.dp),
                 onClick = {
-                    isButtonView = false
+                    onSetDestinationButtonClick()
                 }
             ) {
                 Text(
                     text = "目的地を設定",
                     fontSize = 12.sp,
                     textAlign = TextAlign.Center
-
                 )
             }
         } else {
             Text(
                 text = "スマートフォンの操作を\n待機しています…",
                 fontSize = 12.sp,
-                modifier = Modifier
-                    .padding(top = 90.dp),
                 textAlign = TextAlign.Center
             )
         }
-
-
     }
+}
 
+@Composable
+fun PreviewButton() {
+    var isButtonView by remember { mutableStateOf(true) }
+    val onSetDestinationButtonClick = {
+        isButtonView = false
+    }
+    WaitingScreen(
+        isButtonView = isButtonView,
+        onSetDestinationButtonClick = onSetDestinationButtonClick
+    )
 }
 
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 private fun DefaultPreview() {
-    WaitingScreen()
+    PreviewButton()
 }
 


### PR DESCRIPTION
## 概要

Watch側の待機画面の実装を行った。またボタンを押した後の処理も行っている。

### 関係するタスク
https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=80726648
<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

### 変更内容
デザイン原案を基に文章とボタンを作成し、ボタンを押した後の処理についてはボタンを非表示にしてから文章を表示している

## 動画
<!-- 実装した画面のスクリーンショットを貼りましょう -->
<!-- 必要そうなら変更前後の画像を貼りましょう -->
https://github.com/user-attachments/assets/a8bd82fd-14d8-468f-8a8f-9200e06d3209