### PR TITLE
待機画面のアプリ設定ボタンの作成

### DIFF
--- a/common/resource/src/main/java/jp/ac/mayoi/common/resource/CommonColors.kt
+++ b/common/resource/src/main/java/jp/ac/mayoi/common/resource/CommonColors.kt
@@ -16,7 +16,7 @@ val colorAccentSecondaryCommon = Color(0xFF20C0DD)
 val colorBackgroundPrimaryDarkCommon = Color(0xFF000000)
 val colorBackgroundSecondaryDarkCommon = Color(0xFF4A4A4A)
 val colorTextMainDarkCommon = Color(0xFFF0F0F0)
-val colorBackgroundAppSettingButtonCommon = Color(0xFF868686)
+val colorBackgroundAppSettingButtonCommon = colorTextCaptionCommon
 
 // ButtonColors
 

--- a/common/resource/src/main/java/jp/ac/mayoi/common/resource/CommonColors.kt
+++ b/common/resource/src/main/java/jp/ac/mayoi/common/resource/CommonColors.kt
@@ -16,6 +16,7 @@ val colorAccentSecondaryCommon = Color(0xFF20C0DD)
 val colorBackgroundPrimaryDarkCommon = Color(0xFF000000)
 val colorBackgroundSecondaryDarkCommon = Color(0xFF4A4A4A)
 val colorTextMainDarkCommon = Color(0xFFF0F0F0)
+val colorBackgroundAppSettingButtonCommon = Color(0xFF868686)
 
 // ButtonColors
 

--- a/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Colors.kt
+++ b/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Colors.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.wear.compose.material.ButtonDefaults
 import jp.ac.mayoi.common.resource.colorAccentCommon
 import jp.ac.mayoi.common.resource.colorAccentSecondaryCommon
+import jp.ac.mayoi.common.resource.colorBackgroundAppSettingButtonCommon
 import jp.ac.mayoi.common.resource.colorBackgroundPrimaryDarkCommon
 import jp.ac.mayoi.common.resource.colorBackgroundPrimaryLightCommon
 import jp.ac.mayoi.common.resource.colorBackgroundSecondaryDarkCommon
@@ -19,6 +20,7 @@ val colorTextCaption = colorTextCaptionCommon
 val colorAccent = colorAccentCommon
 val colorAccentSecondary = colorAccentSecondaryCommon
 val colorButtonTextPrimary = colorBackgroundPrimaryLightCommon
+val colorBackgroundAppSettingButton = colorBackgroundAppSettingButtonCommon
 
 // ButtonColors
 
@@ -26,5 +28,11 @@ val buttonColorsDefault
     @Composable get() =
         ButtonDefaults.primaryButtonColors(
             backgroundColor = colorAccent,
+            contentColor = colorButtonTextPrimary
+        )
+val appSettingButtonColors
+    @Composable get() =
+        ButtonDefaults.primaryButtonColors(
+            backgroundColor = colorBackgroundAppSettingButton,
             contentColor = colorButtonTextPrimary
         )

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
@@ -16,9 +16,11 @@ import jp.ac.mayoi.wear.core.resource.MaigoButton
 import jp.ac.mayoi.wear.core.resource.appSettingButtonColors
 
 @Composable
-fun AppSettingButton() {
+fun AppSettingButton(
+    onSettingButtonClick: () -> Unit
+) {
     MaigoButton(
-        onClick = {/*設定画面に遷移される処理*/ },
+        onClick = onSettingButtonClick,
         colors = appSettingButtonColors,
         modifier = Modifier
             .width(138.dp)
@@ -39,7 +41,8 @@ private fun AppSettingButtonPreview() {
             .fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        AppSettingButton()
+        AppSettingButton(
+            onSettingButtonClick = {/*ボタンを押した後の処理をここに書く*/ }
+        )
     }
-
 }

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
@@ -1,0 +1,46 @@
+package jp.ac.mayoi.wear.features.waiting
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.Text
+import androidx.wear.tooling.preview.devices.WearDevices
+import jp.ac.mayoi.wear.core.resource.MaigoButton
+import jp.ac.mayoi.wear.core.resource.appSettingButtonColors
+
+@Composable
+fun AppSettingButton() {
+    MaigoButton(
+        onClick = {/*設定画面に遷移される処理*/ },
+        colors = appSettingButtonColors,
+        modifier = Modifier
+            .width(138.dp)
+            .height(47.dp)
+
+    ) {
+        Text(
+            text = "アプリ設定",
+            fontSize = 12.sp,
+        )
+    }
+}
+
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
+@Composable
+private fun AppSettingButtonPreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        AppSettingButton()
+    }
+
+}

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
@@ -23,7 +23,6 @@ fun AppSettingButton() {
         modifier = Modifier
             .width(138.dp)
             .height(47.dp)
-
     ) {
         Text(
             text = "アプリ設定",

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
@@ -16,7 +16,7 @@ import jp.ac.mayoi.wear.core.resource.MaigoButton
 import jp.ac.mayoi.wear.core.resource.appSettingButtonColors
 
 @Composable
-fun AppSettingButton(
+internal fun AppSettingButton(
     onSettingButtonClick: () -> Unit
 ) {
     MaigoButton(

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/AppSettingButton.kt
@@ -37,9 +37,9 @@ fun AppSettingButton(
 @Composable
 private fun AppSettingButtonPreview() {
     Box(
+        contentAlignment = Alignment.Center,
         modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center
+            .fillMaxSize()
     ) {
         AppSettingButton(
             onSettingButtonClick = {/*ボタンを押した後の処理をここに書く*/ }


### PR DESCRIPTION
## 概要

待機画面を横にスワイプした際のアプリ設定ボタンを実装

### 関係するタスク
https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=80726648
<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->


### 変更内容

新規にAppSettingButton.ktを作成し、アプリ設定ボタンを作成
またボタンの色が異なるためColors.kt,CommonColors.ktにその定義を追加

## 画像
<!-- 実装した画面のスクリーンショットを貼りましょう -->
<!-- 必要そうなら変更前後の画像を貼りましょう -->
![スクリーンショット (484)](https://github.com/user-attachments/assets/543ed471-91d0-411a-b8a8-f54f763260b6)
