### PR TITLE
旅行中にスポットを登録できないように仕様を修正

### DIFF
--- a/phone/core/resource/src/main/res/values/strings.xml
+++ b/phone/core/resource/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="traveling_noNear_spot">この近くにはまだスポットがないようです</string>
-    <string name="traveling_register_firstSpot">あなたが最初のスポットを\n登録してみませんか？</string>
-    <string name="traveling_register_spot">スポットを登録</string>
+    <string name="traveling_no_spot_move">移動して新しいスポットを見つけましょう！</string>
+    <string name="register_spot">スポットを登録</string>
     <string name="traveling_cancel_travel">旅行を中断</string>
 </resources>

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,11 +17,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.resource.StringR
-import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
 internal fun SpotEmptyScreen(
-    onSubmitSpotButtonClick: () -> Unit,
     onTripCancelButtonClick: () -> Unit
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
@@ -42,22 +39,10 @@ internal fun SpotEmptyScreen(
             Text(
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
-                text = stringResource(StringR.traveling_register_firstSpot),
+                text = stringResource(StringR.traveling_no_spot_move),
                 fontSize = 16.sp,
                 lineHeight = 24.sp
             )
-            Spacer(modifier = Modifier.size(24.dp))
-            MaigoButton(
-                onClick = onSubmitSpotButtonClick,
-                modifier = Modifier
-                    .width(240.dp),
-            ) {
-                Text(
-                    fontWeight = FontWeight.Bold,
-                    text = stringResource(StringR.traveling_register_spot),
-                    fontSize = 16.sp
-                )
-            }
         }
         Box(
             modifier = Modifier
@@ -75,7 +60,6 @@ internal fun SpotEmptyScreen(
 private fun TripPreview() {
     MaigoCompassTheme {
         SpotEmptyScreen(
-            onSubmitSpotButtonClick = { },
             onTripCancelButtonClick = { }
         )
     }


### PR DESCRIPTION
## 概要
<!-- ざっくりと変更内容や必要な情報を書く -->

迷子コンパスの統一仕様に基づいて、旅行中にスポットを登録できないように修正した。
比較画像については、左のスクリーンショットが昔のもののため、旅行を中断ボタンが表示されていない状態になっている。

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=84820973

### 変更内容

<!-- 詳細な変更内容を書く -->

- 旅行中にスポットがない場合に表示していたスポットを登録ボタンを消した
- 同時に、文言を修正

## 画像
<!-- 実装した画面のスクリーンショットを貼りましょう -->
<!-- 必要そうなら変更前後の画像を貼りましょう -->

| before | after |
|:------:|:-----:|
|![image](https://github.com/user-attachments/assets/426bab8c-8231-42cb-82f1-3ca11f3e0eed)|![image](https://github.com/user-attachments/assets/48053512-d259-4ce0-9725-25e4c942a4a3)|