### PR TITLE
LoadStateを実装

### DIFF
--- a/phone/core/util/src/main/java/jp/ac/mayoi/core/util/LoadState.kt
+++ b/phone/core/util/src/main/java/jp/ac/mayoi/core/util/LoadState.kt
@@ -1,0 +1,24 @@
+package jp.ac.mayoi.core.util
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+sealed class LoadState<out T> {
+    abstract val value: T?
+
+    @Immutable
+    data class Loading<T>(
+        override val value: T?
+    ) : LoadState<T>()
+
+    @Immutable
+    data class Success<T>(
+        override val value: T,
+    ) : LoadState<T>()
+
+    @Immutable
+    data class Error<T>(
+        override val value: T?,
+        val error: Throwable,
+    ) : LoadState<T>()
+}


### PR DESCRIPTION
## 概要
<!-- ざっくりと変更内容や必要な情報を書く -->

ネットワークからデータをロードしている際の状態を表す`sealed class`を実装した。

実際に使う際は以下のように使う

```kotlin
@Composable
internal fun なんかロードする画面(
    nantokaState: LoadingState<NantokaModel>,
) {
    when(nantokaState) {
        is LoadState.Error {
            // エラー時の画面、処理を書く。
            // 一応valueの値をnullableだけど参照することもできる。
        }
        is LoadState.Loading {
            // ロード中の画面、処理を書く
            // 一応valueの値をnullableだけど参照することもできる。
        }
        is LoadState.Success {
            // ロード完了後の画面、処理を書く。
        }
    }
}
```

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=85320192

