### PR TITLE
初回起動時にユーザーIDを生成する処理を実装

### DIFF
--- a/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
+++ b/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
@@ -1,11 +1,15 @@
 package jp.ac.mayoi.core.application
 
 import android.app.Application
+import android.util.Log
 import jp.ac.mayoi.core.datastore.UserInfoDataStoreWrapper
 import jp.ac.mayoi.service.interfaces.HealthService
 import jp.ac.mayoi.service.interfaces.ImageService
 import jp.ac.mayoi.service.interfaces.RankingService
 import jp.ac.mayoi.service.interfaces.SpotService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import org.koin.android.ext.android.inject
@@ -16,13 +20,19 @@ import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.UUID
 
 abstract class BaseApplication : Application() {
     private val retrofit: Retrofit by inject()
 
+    // Context Leakをしていることに注意
+    private val userInfoDataStoreWrapper = UserInfoDataStoreWrapper(this)
+    private var applicationUserId: String = ""
+
     override fun onCreate() {
         super.onCreate()
 
+        uniqueUserIdStarter()
         koinStarter()
     }
 
@@ -43,6 +53,24 @@ abstract class BaseApplication : Application() {
         }
     }
 
+    private fun uniqueUserIdStarter() {
+        runBlocking(Dispatchers.IO) {
+            val userId: String = userInfoDataStoreWrapper.getUserId().first()
+
+            applicationUserId = if (userId == "") {
+                Log.d("UserID", "User ID Not Found.")
+                val uuid = UUID.randomUUID().toString()
+                userInfoDataStoreWrapper.setUserId(uuid)
+
+                uuid
+            } else {
+                Log.d("UserID", "User ID Found.")
+                userId
+            }
+            Log.d("UserID", "Current User ID: $applicationUserId")
+        }
+    }
+
     private val coreKoinModule = module {
         single {
             // UAなどの設定も後からBuilderに追加する
@@ -55,7 +83,10 @@ abstract class BaseApplication : Application() {
                 )
                 .build()
         }
-        single { UserInfoDataStoreWrapper(get()) }
+        single {
+            // 多分これよくないんだろうなと思ってやってる
+            userInfoDataStoreWrapper
+        }
     }
 
     private val serviceKoinModule = module {

--- a/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
+++ b/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
@@ -32,6 +32,7 @@ abstract class BaseApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // RetrofitのbuildにUserIdが必要なのでここで先にUserIdを作る
         uniqueUserIdStarter()
         koinStarter()
     }


### PR DESCRIPTION
## 概要
<!-- ざっくりと変更内容や必要な情報を書く -->

初回起動時というか、ストレージに有効なユーザーIDが記録されていなかったら生成するようにした。

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=84937383