### PR TITLE
旅行中のスポットリスト画面の作成

### DIFF
--- a/phone/features/traveling/build.gradle.kts
+++ b/phone/features/traveling/build.gradle.kts
@@ -32,6 +32,7 @@ android {
 dependencies {
     implementation(project(":phone:core:util"))
     implementation(project(":phone:core:resource"))
+    implementation(project(":phone:model"))
     implementation(libs.bundles.composeKit)
 
     implementation(libs.androidx.core.ktx)

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -36,9 +36,8 @@ internal fun TravelingSpotScreen(
                 bottom = 92.dp,
             )
         ) {
-            itemsIndexed(spotList) { _, spot ->
+            items(spotList) { spot ->
                 Row(
-                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .padding(horizontal = spacingDouble),
                 ) {
@@ -67,7 +66,6 @@ internal fun TravelingSpotScreen(
     }
 }
 
-
 @Preview(showBackground = true)
 @Composable
 private fun TripPreview() {
@@ -88,7 +86,7 @@ private fun TripPreview() {
         TravelingSpotScreen(
             spotList = rankingTestList,
             onTripCancelButtonClick = { },
-            )
+        )
     }
 }
 

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -31,7 +31,10 @@ internal fun TravelingSpotScreen(
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(spacingDouble),
-            contentPadding = PaddingValues(vertical = spacingDouble),
+            contentPadding = PaddingValues(
+                top = spacingDouble,
+                bottom = 92.dp,
+            )
         ) {
             itemsIndexed(spotList) { _, spot ->
                 Row(

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -34,7 +34,6 @@ internal fun TravelingSpotScreen(
         contentPadding = PaddingValues(vertical = spacingTriple),
     ) {
         itemsIndexed(spotList) { index_, spot ->
-            val index = index_ + 1
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -1,0 +1,84 @@
+package jp.ac.mayoi.traveling
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import jp.ac.mayoi.core.resource.MaigoCompassTheme
+import jp.ac.mayoi.core.resource.spacingDouble
+import jp.ac.mayoi.core.resource.spacingSingle
+import jp.ac.mayoi.core.resource.spacingTriple
+import jp.ac.mayoi.core.util.SpotCard
+import jp.ac.mayoi.phone.model.LocalSpot
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+internal fun TravelingSpotScreen(
+    spotList: ImmutableList<LocalSpot>,
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(spacingTriple),
+        contentPadding = PaddingValues(vertical = spacingTriple),
+    ) {
+        itemsIndexed(spotList) { index_, spot ->
+            val index = index_ + 1
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .padding(horizontal = spacingDouble),
+            ) {
+                Spacer(modifier = Modifier.size(spacingSingle))
+                SpotCard(
+                    spot = spot,
+                    onCardClicked = {},
+                    isClickEnabled = false,
+                    modifier = Modifier
+                        .shadow(
+                            elevation = 4.dp,
+                            shape = RoundedCornerShape(16.dp)
+                        )
+                        .fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun TripPreview() {
+    MaigoCompassTheme {
+        val spot = LocalSpot(
+            lat = 0.0F,
+            lng = 0.0F,
+            message = "Hello From Preview!",
+            imageUrl = "",
+            postUserId = "",
+            reachedCount = 100,
+            createdAt = "2024-10-09T23:31:15+09:00",
+        )
+        val rankingTestList: ImmutableList<LocalSpot> =
+            List(10) {
+                spot
+            }.toImmutableList()
+        TravelingSpotScreen(
+            spotList = rankingTestList,
+
+            )
+    }
+}
+

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -89,4 +89,3 @@ private fun TripPreview() {
         )
     }
 }
-

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -1,8 +1,10 @@
 package jp.ac.mayoi.traveling
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -25,29 +27,40 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 internal fun TravelingSpotScreen(
     spotList: ImmutableList<LocalSpot>,
+    onTripCancelButtonClick: () -> Unit,
 ) {
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(spacingTriple),
-        contentPadding = PaddingValues(vertical = spacingTriple),
-    ) {
-        itemsIndexed(spotList) { index_, spot ->
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .padding(horizontal = spacingDouble),
-            ) {
-                SpotCard(
-                    spot = spot,
-                    onCardClicked = {},
-                    isClickEnabled = false,
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(spacingTriple),
+            contentPadding = PaddingValues(vertical = spacingTriple),
+        ) {
+            itemsIndexed(spotList) { _, spot ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
-                        .shadow(
-                            elevation = 4.dp,
-                            shape = RoundedCornerShape(16.dp)
-                        )
-                        .fillMaxWidth()
-                )
+                        .padding(horizontal = spacingDouble),
+                ) {
+                    SpotCard(
+                        spot = spot,
+                        onCardClicked = {},
+                        isClickEnabled = false,
+                        modifier = Modifier
+                            .shadow(
+                                elevation = 4.dp,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                            .fillMaxWidth()
+                    )
+                }
             }
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+        ) {
+            TripCancelButton(
+                onTripCancelButtonClick = onTripCancelButtonClick,
+            )
         }
     }
 }
@@ -72,7 +85,7 @@ private fun TripPreview() {
             }.toImmutableList()
         TravelingSpotScreen(
             spotList = rankingTestList,
-
+            onTripCancelButtonClick = { },
             )
     }
 }

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -3,10 +3,8 @@ package jp.ac.mayoi.traveling
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -18,7 +16,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.resource.spacingDouble
-import jp.ac.mayoi.core.resource.spacingSingle
 import jp.ac.mayoi.core.resource.spacingTriple
 import jp.ac.mayoi.core.util.SpotCard
 import jp.ac.mayoi.phone.model.LocalSpot
@@ -39,7 +36,6 @@ internal fun TravelingSpotScreen(
                 modifier = Modifier
                     .padding(horizontal = spacingDouble),
             ) {
-                Spacer(modifier = Modifier.size(spacingSingle))
                 SpotCard(
                     spot = spot,
                     onCardClicked = {},

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingSpotScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.resource.spacingDouble
-import jp.ac.mayoi.core.resource.spacingTriple
 import jp.ac.mayoi.core.util.SpotCard
 import jp.ac.mayoi.phone.model.LocalSpot
 import kotlinx.collections.immutable.ImmutableList
@@ -31,8 +30,8 @@ internal fun TravelingSpotScreen(
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(spacingTriple),
-            contentPadding = PaddingValues(vertical = spacingTriple),
+            verticalArrangement = Arrangement.spacedBy(spacingDouble),
+            contentPadding = PaddingValues(vertical = spacingDouble),
         ) {
             itemsIndexed(spotList) { _, spot ->
                 Row(


### PR DESCRIPTION
## 概要
旅行中にスポットリストを表示したときの画面の作成

### 関係するタスク
https://github.com/orgs/mayoi-design/projects/1/views/1?sliceBy%5Bvalue%5D=%E3%82%B9%E3%83%9E%E3%83%9B%E3%82%A2%E3%83%97%E3%83%AA&pane=issue&itemId=86165669

## 画像
![image](https://github.com/user-attachments/assets/a34c1d8e-0c30-4ba5-b514-bf54a94e0012)