### PR TITLE
ScaffoldのContentの中心とGoogleMapsCompose内の中心がずれている問題を修正

### DIFF
--- a/phone/core/resource/src/main/res/drawable/location_fill.xml
+++ b/phone/core/resource/src/main/res/drawable/location_fill.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:pathData="M480.19,467.31q26.89,0 45.85,-19.15T545,402.12q0,-26.89 -19.15,-45.85t-46.04,-18.96q-26.89,0 -45.85,19.15T415,402.5q0,26.88 19.15,45.85 19.15,18.96 46.04,18.96ZM480,860.38Q329,729.54 253.54,616.85q-75.46,-112.7 -75.46,-206.93 0,-138.46 89.57,-224.19Q357.23,100 480,100t212.35,85.73q89.57,85.73 89.57,224.19 0,94.23 -75.46,206.93Q631,729.54 480,860.38Z"
+        android:fillColor="#5f6368" />
+</vector>

--- a/phone/core/resource/src/main/res/drawable/position_set.xml
+++ b/phone/core/resource/src/main/res/drawable/position_set.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960">
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M480,480q33,0 56.5,-23.5T560,400q0,-33 -23.5,-56.5T480,320q-33,0 -56.5,23.5T400,400q0,33 23.5,56.5T480,480ZM480,774q122,-112 181,-203.5T720,408q0,-109 -69.5,-178.5T480,160q-101,0 -170.5,69.5T240,408q0,71 59,162.5T480,774ZM480,880Q319,743 239.5,625.5T160,408q0,-150 96.5,-239T480,80q127,0 223.5,89T800,408q0,100 -79.5,217.5T480,880ZM480,400Z" />
-</vector>

--- a/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboardingScreen.kt
+++ b/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboardingScreen.kt
@@ -26,8 +26,6 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapUiSettings
-import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import jp.ac.mayoi.core.resource.DrawableR
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
@@ -54,21 +52,18 @@ fun OnboardingScreen(
         onCameraPositionChanged(cameraPositionState.position.target)
     }
 
-    Box() {
+    Box {
         GoogleMap(
             uiSettings = MapUiSettings(
                 zoomControlsEnabled = false,
             ),
             cameraPositionState = cameraPositionState,
             contentPadding = PaddingValues(
-                bottom = 92.dp,
-                start = spacingDouble
+                vertical = 92.dp,
+                horizontal = spacingDouble,
             ),
             modifier = Modifier.fillMaxSize()
-        ) {
-            //GoogleMapのマーカーで真ん中をさしたい
-            Marker(state = MarkerState(cameraPositionState.position.target))
-        }
+        )
 
         //画像で真ん中さしてみるマーカー
         Icon(

--- a/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboardingScreen.kt
+++ b/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboardingScreen.kt
@@ -30,7 +30,6 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import jp.ac.mayoi.core.resource.DrawableR
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.resource.StringR
-import jp.ac.mayoi.core.resource.colorAccent
 import jp.ac.mayoi.core.resource.colorAccentSecondary
 import jp.ac.mayoi.core.resource.spacingDouble
 import jp.ac.mayoi.core.resource.spacingSingle
@@ -65,15 +64,14 @@ fun OnboardingScreen(
             modifier = Modifier.fillMaxSize()
         )
 
-        //画像で真ん中さしてみるマーカー
         Icon(
-            painter = painterResource(jp.ac.mayoi.core.resource.R.drawable.position_set),
+            painter = painterResource(DrawableR.location_fill),
             contentDescription = null,
-            tint = colorAccent,
+            tint = Color.Red,
             modifier = Modifier
                 .size(48.dp)
                 .align(Alignment.Center)
-                .offset(y = (-24).dp)
+                .offset(y = (-24).dp) // アイコンの下が現在のtargetになるようずらす
         )
 
         Column(


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

CameraPositionStateの位置がずれていたわけではなく、GoogleMapsComposeに設定したcontentPaddingの影響で、ScaffoldのContentの中心座標とズレが発生しているように見えていた。  
具体的には、GoogleMapsCompose内の座標系が右に`spacingDouble`、上に`96.dp`ずれていたので、contentPaddingを右と上にもつけるようにした。  

これにより、GoogleMaps上に書かれるwidgetは上下左右設定した余白だけ空いて表示されることになるが、実機で確認した感じ、Map上の建物の情報などはContentPaddingの影響を受けないようだった + このアプリでは他にMap上に表示するMarkerなどがないため、これでも問題ないと判断した。