### PR TITLE
目的地を設定できるよう、画面の中心の緯度経度をviewModelに渡せるようにした

### DIFF
--- a/phone/app/build.gradle.kts
+++ b/phone/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.bundles.maps)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -18,6 +18,7 @@ import jp.ac.mayoi.core.navigation.ShareNavigation
 import jp.ac.mayoi.core.navigation.TravelingNavigation
 import jp.ac.mayoi.onboarding.OnboardingScreen
 import jp.ac.mayoi.onboarding.OnboardingViewModel
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun PhoneNavHost(
@@ -30,9 +31,9 @@ fun PhoneNavHost(
         modifier = Modifier.padding(innerPadding)
     ) {
         composable<OnboardingNavigation> {
-            val viewModel = OnboardingViewModel()
+            val onboardingViewModel: OnboardingViewModel = koinViewModel()
             OnboardingScreen(
-                onCameraPositionChanged = viewModel::onCameraChanged,
+                onCameraPositionChanged = onboardingViewModel::onCameraChanged,
                 onDecideClicked = {
                     navController.navigate(TravelingNavigation)
                 },

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -33,7 +33,9 @@ fun PhoneNavHost(
             val viewModel = OnboardingViewModel()
             OnboardingScreen(
                 onCameraPositionChanged = viewModel::onCameraChanged,
-                onDecideClicked = {},
+                onDecideClicked = {
+                    navController.navigate(TravelingNavigation)
+                },
                 onCurrentPositionClicked = {},
             )
         }

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -17,6 +17,7 @@ import jp.ac.mayoi.core.navigation.RankingNavigation
 import jp.ac.mayoi.core.navigation.ShareNavigation
 import jp.ac.mayoi.core.navigation.TravelingNavigation
 import jp.ac.mayoi.onboarding.OnboardingScreen
+import jp.ac.mayoi.onboarding.OnboardingViewModel
 
 @Composable
 fun PhoneNavHost(
@@ -29,7 +30,9 @@ fun PhoneNavHost(
         modifier = Modifier.padding(innerPadding)
     ) {
         composable<OnboardingNavigation> {
+            val viewModel = OnboardingViewModel()
             OnboardingScreen(
+                onCameraPositionChanged = viewModel::onCameraChanged,
                 onDecideClicked = {},
                 onCurrentPositionClicked = {},
             )

--- a/phone/core/application/build.gradle.kts
+++ b/phone/core/application/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 dependencies {
     implementation(project(":phone:service:interfaces"))
     implementation(project(":phone:core:datastore"))
-
+    implementation(project(":phone:features:onboarding"))
     implementation(libs.bundles.composeKit)
     implementation(platform(libs.koin.bom))
     implementation(libs.bundles.koin)

--- a/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
+++ b/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
@@ -3,6 +3,7 @@ package jp.ac.mayoi.core.application
 import android.app.Application
 import android.util.Log
 import jp.ac.mayoi.core.datastore.UserInfoDataStoreWrapper
+import jp.ac.mayoi.onboarding.OnboardingViewModel
 import jp.ac.mayoi.service.interfaces.HealthService
 import jp.ac.mayoi.service.interfaces.ImageService
 import jp.ac.mayoi.service.interfaces.RankingService
@@ -102,6 +103,6 @@ abstract class BaseApplication : Application() {
     }
 
     private val viewModelKoinModule = module {
-
+        single { OnboardingViewModel() }
     }
 }

--- a/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
+++ b/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
@@ -18,6 +18,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidFileProperties
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -103,6 +104,6 @@ abstract class BaseApplication : Application() {
     }
 
     private val viewModelKoinModule = module {
-        single { OnboardingViewModel() }
+        viewModel { OnboardingViewModel() }
     }
 }

--- a/phone/core/resource/src/main/res/drawable/position_set.xml
+++ b/phone/core/resource/src/main/res/drawable/position_set.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M480,480q33,0 56.5,-23.5T560,400q0,-33 -23.5,-56.5T480,320q-33,0 -56.5,23.5T400,400q0,33 23.5,56.5T480,480ZM480,774q122,-112 181,-203.5T720,408q0,-109 -69.5,-178.5T480,160q-101,0 -170.5,69.5T240,408q0,71 59,162.5T480,774ZM480,880Q319,743 239.5,625.5T160,408q0,-150 96.5,-239T480,80q127,0 223.5,89T800,408q0,100 -79.5,217.5T480,880ZM480,400Z" />
+</vector>

--- a/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboardingScreen.kt
+++ b/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboardingScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -13,6 +14,7 @@ import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,10 +26,13 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import jp.ac.mayoi.core.resource.DrawableR
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
 import jp.ac.mayoi.core.resource.StringR
+import jp.ac.mayoi.core.resource.colorAccent
 import jp.ac.mayoi.core.resource.colorAccentSecondary
 import jp.ac.mayoi.core.resource.spacingDouble
 import jp.ac.mayoi.core.resource.spacingSingle
@@ -36,13 +41,19 @@ import jp.ac.mayoi.core.util.MaigoButton
 
 @Composable
 fun OnboardingScreen(
+    onCameraPositionChanged: (LatLng) -> Unit,
     onCurrentPositionClicked: () -> Unit,
-    onDecideClicked: () -> Unit,
+    onDecideClicked: () -> Unit
 ) {
-    val singapore = LatLng(1.35, 103.87)
+    val hakodate = LatLng(41.842140, 140.767)
     val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(singapore, 10f)
+        position = CameraPosition.fromLatLngZoom(hakodate, 15f)
     }
+
+    LaunchedEffect(cameraPositionState.position.target) {
+        onCameraPositionChanged(cameraPositionState.position.target)
+    }
+
     Box() {
         GoogleMap(
             uiSettings = MapUiSettings(
@@ -54,7 +65,22 @@ fun OnboardingScreen(
                 start = spacingDouble
             ),
             modifier = Modifier.fillMaxSize()
+        ) {
+            //GoogleMapのマーカーで真ん中をさしたい
+            Marker(state = MarkerState(cameraPositionState.position.target))
+        }
+
+        //画像で真ん中さしてみるマーカー
+        Icon(
+            painter = painterResource(jp.ac.mayoi.core.resource.R.drawable.position_set),
+            contentDescription = null,
+            tint = colorAccent,
+            modifier = Modifier
+                .size(48.dp)
+                .align(Alignment.Center)
+                .offset(y = (-24).dp)
         )
+
         Column(
             horizontalAlignment = Alignment.End,
             modifier = Modifier
@@ -98,8 +124,9 @@ fun OnboardingScreen(
 private fun OnboardingScreenPreview() {
     MaigoCompassTheme {
         OnboardingScreen(
+            onCameraPositionChanged = {},
             onDecideClicked = {},
-            onCurrentPositionClicked = {}
+            onCurrentPositionClicked = {},
         )
     }
 }

--- a/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
+++ b/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
@@ -1,0 +1,18 @@
+package jp.ac.mayoi.onboarding
+
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.google.android.gms.maps.model.LatLng
+
+class OnboardingViewModel : ViewModel() {
+    var currentPosition: LatLng by mutableStateOf(LatLng(0.0, 0.0))
+        private set
+
+    fun onCameraChanged(newPosition: LatLng) {
+        currentPosition = newPosition
+        Log.d("onboarding", currentPosition.toString())
+    }
+}

--- a/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
+++ b/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
@@ -1,6 +1,5 @@
 package jp.ac.mayoi.onboarding
 
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -13,6 +12,5 @@ class OnboardingViewModel : ViewModel() {
 
     fun onCameraChanged(newPosition: LatLng) {
         currentPosition = newPosition
-        Log.d("onboarding", currentPosition.toString())
     }
 }

--- a/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
+++ b/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
@@ -7,10 +7,10 @@ import androidx.lifecycle.ViewModel
 import com.google.android.gms.maps.model.LatLng
 
 class OnboardingViewModel : ViewModel() {
-    var currentPosition: LatLng by mutableStateOf(LatLng(0.0, 0.0))
+    var destination: LatLng by mutableStateOf(LatLng(0.0, 0.0))
         private set
 
     fun onCameraChanged(newPosition: LatLng) {
-        currentPosition = newPosition
+        destination = newPosition
     }
 }


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->
目的地を設定できるよう、画面の中心の緯度経度をviewModelに渡せるようにした。


### 関係するタスク
旅行開始画面で緯度経度を指定できるようにする
https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=84818760
<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

### 変更内容
目的地を設定できるよう、画面の中心の緯度経度をcameraPositionState.position.targetから取得し、viewModelに渡せるようにした。
Iconを使って中心を指すマーカーを設置した。
目的地を設定ボタンを押したらtravelingScreenに遷移できるようnavHostを設定した。
<!-- 詳細な変更内容を書く -->

## テスト

<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

## 画像
<img src="https://github.com/user-attachments/assets/66eaebf5-f9fa-416f-aebc-450356097e1d" width="200">