### PR TITLE
getBearingが間違った値を返している問題を修正

### DIFF
--- a/wear/repository/implementations/src/main/java/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImpl.kt
+++ b/wear/repository/implementations/src/main/java/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImpl.kt
@@ -39,10 +39,8 @@ class LocationRepositoryImpl : LocationRepository {
         val convertedLatitude = destinationLat - currentLat
         val convertedLongitude = destinationLng - currentLng
         val thetaInRad = atan2(convertedLatitude, convertedLongitude)
-        // Log.d("getHeddingTo", "phiInRad: $thetaInRad")
         val theta = Math.toDegrees(thetaInRad).mod(360.0)
-        // Log.d("getHeddingTo", "headTo: $theta")
 
-        return (theta - currentHeading).mod(360.0)
+        return (theta - 90.0 + currentHeading).mod(360.0)
     }
 }

--- a/wear/repository/implementations/src/main/java/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImpl.kt
+++ b/wear/repository/implementations/src/main/java/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package jp.ac.mayoi.wear.repository.implementations
 
 import android.location.Location
+import android.util.Log
 import jp.ac.mayoi.wear.repository.interfaces.LocationRepository
 import kotlin.math.atan2
 
@@ -10,9 +11,33 @@ class LocationRepositoryImpl : LocationRepository {
         destination: Location,
         currentHeading: Double,
     ): Double {
-        val convertedLatitude = destination.latitude - current.latitude
-        val convertedLongitude = destination.longitude - current.longitude
-        // Log.d("getHeaddingTo", "converted: ($convertedLatitude, $convertedLongitude)")
+        val bearing = getBearing(
+            currentLat = current.latitude,
+            currentLng = current.longitude,
+            destinationLat = destination.latitude,
+            destinationLng = destination.longitude,
+            currentHeading = currentHeading,
+        )
+
+        Log.d(
+            "LocationRepository",
+            "CurrentLocation: (lat = ${current.latitude}, lng = ${current.longitude}), " +
+                    "Destination: (lat = ${destination.latitude}, lng = ${current.longitude}), " +
+                    "HeadingTo: $currentHeading, Bearing: $bearing"
+        )
+
+        return bearing
+    }
+
+    internal fun getBearing(
+        currentLat: Double,
+        currentLng: Double,
+        destinationLat: Double,
+        destinationLng: Double,
+        currentHeading: Double,
+    ): Double {
+        val convertedLatitude = destinationLat - currentLat
+        val convertedLongitude = destinationLng - currentLng
         val thetaInRad = atan2(convertedLatitude, convertedLongitude)
         // Log.d("getHeddingTo", "phiInRad: $thetaInRad")
         val theta = Math.toDegrees(thetaInRad).mod(360.0)

--- a/wear/repository/implementations/src/test/kotlin/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImplTest.kt
+++ b/wear/repository/implementations/src/test/kotlin/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImplTest.kt
@@ -9,9 +9,10 @@ class LocationRepositoryImplTest {
     // 1. 現在地と目的地と向いている方位角を決める
     // 2. 方位角を方位系から数学系に直す
     // 3. (x, y) = (1, 0)を回転行列を用いて2で求めた数学系の角度だけ回す
-    // 3.1. 新しい点の位置を ax, ay とする
+    //   3.1. 新しい点の位置を ax, ay とする
     // 4. 目的地に向かうベクトルを計算し、その座標をbx, byとする
     // 5. θ = acos((ax*bx + ay*by) / (sqrt(ax**2 + ay**2)*sqrt(bx**2 + by**2))) を計算する
+    //   5.1 偏角のうち小さい方がθになるので、適宜外角に直したりする
 
     @Test
     fun `365から函館駅へ`() {
@@ -77,7 +78,7 @@ class LocationRepositoryImplTest {
         // 昭和ターミナル方面を向く (数学系では120°)
         val currentHeading = 330.0
 
-        // 亀田支所前から昭和ターミナル方面を向いた時、函館空港はほぼ真後ろにあるはず
+        // 亀田支所前から昭和ターミナル方面を向いた時、函館空港は南南東か南東にあるはず
         val expected = 360.0 - 151.6443253181512
         val actual = LocationRepositoryImpl()
             .getBearing(

--- a/wear/repository/implementations/src/test/kotlin/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImplTest.kt
+++ b/wear/repository/implementations/src/test/kotlin/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImplTest.kt
@@ -1,0 +1,89 @@
+package jp.ac.mayoi.wear.repository.implementations
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@Suppress("NonAsciiCharacters", "TestFunctionName")
+class LocationRepositoryImplTest {
+
+    @Test
+    fun `365から函館駅へ`() {
+        // 365
+        val currentLat = 41.842116783883995
+        val currentLng = 140.76710646276334
+
+        // 函館駅
+        val destinationLat = 41.773674691098705
+        val destinationLng = 140.72677811248317
+        val currentHeading = 0.0
+
+        // https://www.wolframalpha.com/input?i2d=true&i=atan2%5C%2840%2941.773674691098705+-+41.842116783883995%5C%2844%29+140.72677811248317+-+140.76710646276334%5C%2841%29+*+Divide%5B180%2CPI%5D+-+90+mod+360
+        // 365室前から真北を向いた時、函館駅は南南西方面にある
+        val expected = 149.49199786282
+        val actual = LocationRepositoryImpl()
+            .getBearing(
+                currentLat = currentLat,
+                currentLng = currentLng,
+                destinationLat = destinationLat,
+                destinationLng = destinationLng,
+                currentHeading = currentHeading,
+            )
+
+        assertEquals(expected, actual, 0.0001)
+    }
+
+    @Test
+    fun 函館駅から湯倉神社へ() {
+        // 函館駅
+        val currentLat = 41.773674691098705
+        val currentLng = 140.72677811248317
+
+        // 湯倉神社
+        val destinationLat = 41.781998336369114
+        val destinationLng = 140.79100220973095
+
+        val currentHeading = 0.0
+
+        // https://www.wolframalpha.com/input?i2d=true&i=atan2%5C%2840%2941.781998336369114+-+41.773674691098705%5C%2844%29+140.79100220973095+-+140.72677811248317%5C%2841%29+*+Divide%5B180%2CPI%5D+-+90+mod+360
+        // 函館駅前から真北を向いた時、湯倉神社は東北東方面にある
+        val expected = 277.38455101414
+        val actual = LocationRepositoryImpl()
+            .getBearing(
+                currentLat = currentLat,
+                currentLng = currentLng,
+                destinationLat = destinationLat,
+                destinationLng = destinationLng,
+                currentHeading = currentHeading,
+            )
+
+        assertEquals(expected, actual, 0.0001)
+    }
+
+    @Test
+    fun 亀田支所前から昭和ターミナル方面を向いた時の函館空港() {
+        // 亀田支所前
+        val currentLat = 41.815447973759994
+        val currentLng = 140.75185069083656
+
+        // 函館空港
+        val destinationLat = 41.77596538110248
+        val destinationLng = 140.81591755754837
+
+        // 昭和ターミナル方面を向く ()
+        val currentHeading = 330.0
+
+        // https://www.wolframalpha.com/input?i2d=true&i=atan2%5C%2840%2941.781998336369114+-+41.773674691098705%5C%2844%29+140.79100220973095+-+140.72677811248317%5C%2841%29+*+Divide%5B180%2CPI%5D+-+90+mod+360
+        // 亀田支所前から昭和ターミナル方面を向いた時、函館空港はほぼ真後ろにあるはず
+        val expected = 277.38455101414
+        val actual = LocationRepositoryImpl()
+            .getBearing(
+                currentLat = currentLat,
+                currentLng = currentLng,
+                destinationLat = destinationLat,
+                destinationLng = destinationLng,
+                currentHeading = currentHeading,
+            )
+
+        assertEquals(expected, actual, 0.0001)
+    }
+}

--- a/wear/repository/implementations/src/test/kotlin/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImplTest.kt
+++ b/wear/repository/implementations/src/test/kotlin/jp/ac/mayoi/wear/repository/implementations/LocationRepositoryImplTest.kt
@@ -5,6 +5,13 @@ import org.junit.Test
 
 @Suppress("NonAsciiCharacters", "TestFunctionName")
 class LocationRepositoryImplTest {
+    // テストケースの作り方
+    // 1. 現在地と目的地と向いている方位角を決める
+    // 2. 方位角を方位系から数学系に直す
+    // 3. (x, y) = (1, 0)を回転行列を用いて2で求めた数学系の角度だけ回す
+    // 3.1. 新しい点の位置を ax, ay とする
+    // 4. 目的地に向かうベクトルを計算し、その座標をbx, byとする
+    // 5. θ = acos((ax*bx + ay*by) / (sqrt(ax**2 + ay**2)*sqrt(bx**2 + by**2))) を計算する
 
     @Test
     fun `365から函館駅へ`() {
@@ -17,9 +24,8 @@ class LocationRepositoryImplTest {
         val destinationLng = 140.72677811248317
         val currentHeading = 0.0
 
-        // https://www.wolframalpha.com/input?i2d=true&i=atan2%5C%2840%2941.773674691098705+-+41.842116783883995%5C%2844%29+140.72677811248317+-+140.76710646276334%5C%2841%29+*+Divide%5B180%2CPI%5D+-+90+mod+360
         // 365室前から真北を向いた時、函館駅は南南西方面にある
-        val expected = 149.49199786282
+        val expected = 149.49199786282134
         val actual = LocationRepositoryImpl()
             .getBearing(
                 currentLat = currentLat,
@@ -44,7 +50,6 @@ class LocationRepositoryImplTest {
 
         val currentHeading = 0.0
 
-        // https://www.wolframalpha.com/input?i2d=true&i=atan2%5C%2840%2941.781998336369114+-+41.773674691098705%5C%2844%29+140.79100220973095+-+140.72677811248317%5C%2841%29+*+Divide%5B180%2CPI%5D+-+90+mod+360
         // 函館駅前から真北を向いた時、湯倉神社は東北東方面にある
         val expected = 277.38455101414
         val actual = LocationRepositoryImpl()
@@ -69,12 +74,11 @@ class LocationRepositoryImplTest {
         val destinationLat = 41.77596538110248
         val destinationLng = 140.81591755754837
 
-        // 昭和ターミナル方面を向く ()
+        // 昭和ターミナル方面を向く (数学系では120°)
         val currentHeading = 330.0
 
-        // https://www.wolframalpha.com/input?i2d=true&i=atan2%5C%2840%2941.781998336369114+-+41.773674691098705%5C%2844%29+140.79100220973095+-+140.72677811248317%5C%2841%29+*+Divide%5B180%2CPI%5D+-+90+mod+360
         // 亀田支所前から昭和ターミナル方面を向いた時、函館空港はほぼ真後ろにあるはず
-        val expected = 277.38455101414
+        val expected = 360.0 - 151.6443253181512
         val actual = LocationRepositoryImpl()
             .getBearing(
                 currentLat = currentLat,


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

現在向いている方位角から目的地までの偏角を取得するgetBearingが誤った値を返していた。  
一度 [処理を明文化](https://scrapbox.io/PBL2024mayoi/%E7%9B%AE%E7%9A%84%E5%9C%B0%E3%81%AE%E6%96%B9%E5%90%91%E3%81%AF%E4%BB%8A%E3%81%AE%E5%90%91%E3%81%84%E3%81%A6%E3%81%84%E3%82%8B%E6%96%B9%E5%90%91%E3%81%8B%E3%82%89%E4%BD%95%E5%BA%A6%E3%81%9A%E3%82%8C%E3%81%A6%E3%81%84%E3%82%8B%E3%81%8B%EF%BC%9F) し、そのとおりになるよう実装を修正した。

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=87969844
- https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=88224619

### 変更内容

<!-- 詳細な変更内容を書く -->

- getBearingのテストを書いた
  - 元のままではUnitテストで動かせなかったので、internalなメソッドを作成し、ラッピングして利用するようにした。
- Scrapboxに処理のドキュメントを書いた
- getBearingの実装を修正した

## テスト

<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

- 任意の目的地、おすすめスポットに対して、正しいbearingを返すことができる。
  - ただし、Watchが取得する方位角は正しいものとする。