### PR TITLE
travelingViewModelが初期化時にクラッシュする問題を修正

### DIFF
--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingViewModel.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingViewModel.kt
@@ -42,6 +42,12 @@ class TravelingViewModel(
 ) : ViewModel() {
     var headingTo by mutableDoubleStateOf(0.0)
         private set
+    private val currentLocation = run {
+        Location(null).also {
+            it.latitude = 0.0
+            it.longitude = 0.0
+        }
+    }
     private var remoteRecommendSpot: List<RemoteSpotShrink> = listOf()
 
     // recommendSpotとdestinationの実装終わってるからどうにかしたい
@@ -62,23 +68,7 @@ class TravelingViewModel(
             distance = currentLocation.distanceTo(_destination).toDouble(),
             bearing = locationRepository.getBearing(currentLocation, _destination, headingTo)
         )
-    var focusing by mutableStateOf(
-        RecommendSpot(
-            lat = _destination.latitude,
-            lng = _destination.longitude,
-            comment = "",
-            distance = 0.0, // クラッシュするので一旦これで置いてます
-            bearing = 0.0 // クラッシュするので一旦これで置いてます
-        )
-    )
-
-
-    private val currentLocation = run {
-        Location(null).also {
-            it.latitude = 0.0
-            it.longitude = 0.0
-        }
-    }
+    var focusing: RecommendSpot by mutableStateOf(destination)
 
     private val rotationVectorSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
 


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

`ryoka-1104/traveling_navigation` 旅行中画面を開いた際、TravelingViewModelがクラッシュする問題を修正した

### クラッシュ原因

- currentLocation が初期化される前に currentLocation の値にアクセスしていること
  - currentLocationを早めに初期化するようにするため、変数宣言の順番を入れ替えた