### PR TITLE
bottomNavigationを出す画面と出さない画面を分けた

### DIFF
--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -51,10 +51,14 @@ fun PhoneNavHost(
             }
         }
         composable<ShareNavigation> {
-
+            Box(modifier = Modifier.fillMaxSize()) {
+                Text("ShareScreen")
+            }
         }
         composable<TravelingNavigation> {
-
+            Box(modifier = Modifier.fillMaxSize()) {
+                Text("TravelingScreen")
+            }
         }
     }
 }

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -51,14 +51,10 @@ fun PhoneNavHost(
             }
         }
         composable<ShareNavigation> {
-            Box(modifier = Modifier.fillMaxSize()) {
-                Text("ShareScreen")
-            }
+
         }
         composable<TravelingNavigation> {
-            Box(modifier = Modifier.fillMaxSize()) {
-                Text("TravelingScreen")
-            }
+
         }
     }
 }

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/RootScreen.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/RootScreen.kt
@@ -11,10 +11,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -32,23 +34,26 @@ fun RootScreen(
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination?.hierarchy
+    val isShowBottomBar = remember(navController.currentDestination) {
+        listOf(
+            OnboardingNavigation::class,
+            RankingNavigation::class,
+            MemoryNavigation::class,
+        ).any { navController.currentDestination?.hasRoute(it) == true }
+    }
 
     Scaffold(
         bottomBar = {
-            if (currentDestination?.any {
-                    it.route == OnboardingNavigation::class.qualifiedName ||
-                            it.route == RankingNavigation::class.qualifiedName ||
-                            it.route == MemoryNavigation::class.qualifiedName
-                } == true) {
+            if (isShowBottomBar) {
                 NavigationBar {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceAround
                     ) {
                         NavigationBarItem(
-                            selected = currentDestination.any {
+                            selected = currentDestination?.any {
                                 it.route == OnboardingNavigation::class.qualifiedName
-                            },
+                            } == true,
                             onClick = { navController.navigate(OnboardingNavigation) },
                             icon = {
                                 Icon(
@@ -66,9 +71,9 @@ fun RootScreen(
                             colors = maigoNavigationBarItemColors,
                         )
                         NavigationBarItem(
-                            selected = currentDestination.any {
+                            selected = currentDestination?.any {
                                 it.route == RankingNavigation::class.qualifiedName
-                            },
+                            } == true,
                             onClick = { navController.navigate(RankingNavigation) },
                             icon = {
                                 Icon(
@@ -86,9 +91,9 @@ fun RootScreen(
                             colors = maigoNavigationBarItemColors,
                         )
                         NavigationBarItem(
-                            selected = currentDestination.any {
+                            selected = currentDestination?.any {
                                 it.route == MemoryNavigation::class.qualifiedName
-                            },
+                            } == true,
                             onClick = { navController.navigate(MemoryNavigation) },
                             icon = {
                                 Icon(

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/RootScreen.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/RootScreen.kt
@@ -35,71 +35,77 @@ fun RootScreen(
 
     Scaffold(
         bottomBar = {
-            NavigationBar {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceAround
-                ) {
-                    NavigationBarItem(
-                        selected = currentDestination?.any {
-                            it.route == OnboardingNavigation::class.qualifiedName
-                        } == true,
-                        onClick = { navController.navigate(OnboardingNavigation) },
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.navbaritem_travel),
-                                contentDescription = null,
-                                modifier = Modifier.size(40.dp),
-                            )
-                        },
-                        label = {
-                            Text(
-                                text = "旅をする",
-                                style = textStyleCaption,
-                            )
-                        },
-                        colors = maigoNavigationBarItemColors,
-                    )
-                    NavigationBarItem(
-                        selected = currentDestination?.any {
-                            it.route == RankingNavigation::class.qualifiedName
-                        } == true,
-                        onClick = { navController.navigate(RankingNavigation) },
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.navbaritem_ranking),
-                                contentDescription = null,
-                                modifier = Modifier.size(40.dp),
-                            )
-                        },
-                        label = {
-                            Text(
-                                text = "ランキング",
-                                style = textStyleCaption,
-                            )
-                        },
-                        colors = maigoNavigationBarItemColors,
-                    )
-                    NavigationBarItem(
-                        selected = currentDestination?.any {
+            if (currentDestination?.any {
+                    it.route == OnboardingNavigation::class.qualifiedName ||
+                            it.route == RankingNavigation::class.qualifiedName ||
                             it.route == MemoryNavigation::class.qualifiedName
-                        } == true,
-                        onClick = { navController.navigate(MemoryNavigation) },
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.navbaritem_memory),
-                                contentDescription = null,
-                                modifier = Modifier.size(40.dp),
-                            )
-                        },
-                        label = {
-                            Text(
-                                text = "おもいで",
-                                style = textStyleCaption,
-                            )
-                        },
-                        colors = maigoNavigationBarItemColors,
-                    )
+                } == true) {
+                NavigationBar {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceAround
+                    ) {
+                        NavigationBarItem(
+                            selected = currentDestination.any {
+                                it.route == OnboardingNavigation::class.qualifiedName
+                            },
+                            onClick = { navController.navigate(OnboardingNavigation) },
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.navbaritem_travel),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(40.dp),
+                                )
+                            },
+                            label = {
+                                Text(
+                                    text = "旅をする",
+                                    style = textStyleCaption,
+                                )
+                            },
+                            colors = maigoNavigationBarItemColors,
+                        )
+                        NavigationBarItem(
+                            selected = currentDestination.any {
+                                it.route == RankingNavigation::class.qualifiedName
+                            },
+                            onClick = { navController.navigate(RankingNavigation) },
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.navbaritem_ranking),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(40.dp),
+                                )
+                            },
+                            label = {
+                                Text(
+                                    text = "ランキング",
+                                    style = textStyleCaption,
+                                )
+                            },
+                            colors = maigoNavigationBarItemColors,
+                        )
+                        NavigationBarItem(
+                            selected = currentDestination.any {
+                                it.route == MemoryNavigation::class.qualifiedName
+                            },
+                            onClick = { navController.navigate(MemoryNavigation) },
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.navbaritem_memory),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(40.dp),
+                                )
+                            },
+                            label = {
+                                Text(
+                                    text = "おもいで",
+                                    style = textStyleCaption,
+                                )
+                            },
+                            colors = maigoNavigationBarItemColors,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 概要
ボトムバーを出す画面と出さない画面を分けました

### 関係するタスク
bottomBarを表示する画面と表示しない画面を分ける
https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=87349970
<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->


### 変更内容
currentDestinationによって、onboard,ranking,memory画面の時だけボトムバーを表示するようにしました。
確認のため、travelingScreenにテキストを書きました。
<!-- 詳細な変更内容を書く -->
## テスト

<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

## 画像
<!-- 実装した画面のスクリーンショットを貼りましょう -->
<!-- 必要そうなら変更前後の画像を貼りましょう -->
<img src="https://github.com/user-attachments/assets/fca6be27-8b2c-4a41-afec-8f0d545bcd08" width="200">