### PR TITLE
旅行中画面でおすすめスポットをポーリングする処理を実装

### DIFF
--- a/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
+++ b/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
@@ -1,0 +1,5 @@
+package jp.ac.mayoi.common.resource
+
+const val locationIntentAction = "MAIGO_COMPASS_LOCATION_BROADCAST"
+const val locationIntentLatitude = "Latitude"
+const val locationIntentLongitude = "Longitude"

--- a/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
+++ b/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
@@ -3,3 +3,4 @@ package jp.ac.mayoi.common.resource
 const val locationIntentAction = "MAIGO_COMPASS_LOCATION_BROADCAST"
 const val locationIntentLatitude = "Latitude"
 const val locationIntentLongitude = "Longitude"
+const val locationPolingInterval = "Location_Poling_Interval"

--- a/phone/app/build.gradle.kts
+++ b/phone/app/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     implementation(project(":phone:features:onboarding"))
     implementation(project(":phone:features:ranking"))
     implementation(project(":phone:core:navigation"))
+    implementation(project(":wear:service"))
     implementation(libs.kotlinx.coroutine.android)
     implementation(platform(libs.koin.bom))
     implementation(libs.bundles.koin)

--- a/phone/app/build.gradle.kts
+++ b/phone/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation(project(":phone:repository:interfaces"))
     implementation(project(":phone:features:onboarding"))
     implementation(project(":phone:features:ranking"))
+    implementation(project(":phone:features:traveling"))
     implementation(project(":phone:core:navigation"))
     implementation(project(":wear:service"))
     implementation(libs.kotlinx.coroutine.android)

--- a/phone/app/src/main/AndroidManifest.xml
+++ b/phone/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name="jp.ac.mayoi.wear.service.LocationService"
+            android:foregroundServiceType="location" />
     </application>
 
 </manifest>

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -19,6 +19,8 @@ import jp.ac.mayoi.core.navigation.TravelingNavigation
 import jp.ac.mayoi.onboarding.OnboardingScreen
 import jp.ac.mayoi.onboarding.OnboardingViewModel
 import jp.ac.mayoi.ranking.RankingScreen
+import jp.ac.mayoi.traveling.ParentScreen
+import jp.ac.mayoi.traveling.TravelingViewModel
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -55,7 +57,16 @@ fun PhoneNavHost(
 
         }
         composable<TravelingNavigation> {
-
+            val travelingViewModel: TravelingViewModel = koinViewModel()
+            ParentScreen(
+                viewModel = travelingViewModel,
+                onTripCancelButtonClick = {
+                    navController.popBackStack()
+                },
+                onRetryButtonClick = {
+                    travelingViewModel.getNearSpot()
+                }
+            )
         }
     }
 }

--- a/phone/features/traveling/build.gradle.kts
+++ b/phone/features/traveling/build.gradle.kts
@@ -33,7 +33,9 @@ dependencies {
     implementation(project(":phone:repository:interfaces"))
     implementation(project(":phone:core:util"))
     implementation(project(":phone:core:resource"))
+    implementation(project(":common:resource"))
     implementation(project(":phone:model"))
+    implementation(project(":wear:service"))
     implementation(libs.bundles.composeKit)
 
     implementation(libs.androidx.core.ktx)

--- a/phone/features/traveling/src/main/AndroidManifest.xml
+++ b/phone/features/traveling/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+</manifest>

--- a/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingViewModel.kt
+++ b/phone/features/traveling/src/main/java/jp/ac/mayoi/traveling/TravelingViewModel.kt
@@ -1,15 +1,27 @@
 package jp.ac.mayoi.traveling
 
+import android.annotation.SuppressLint
+import android.app.Activity.RECEIVER_EXPORTED
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.location.Location
+import android.os.Build
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import jp.ac.mayoi.common.resource.locationIntentAction
+import jp.ac.mayoi.common.resource.locationIntentLatitude
+import jp.ac.mayoi.common.resource.locationIntentLongitude
+import jp.ac.mayoi.common.resource.locationPolingInterval
 import jp.ac.mayoi.core.util.LoadState
 import jp.ac.mayoi.phone.model.LocalSpot
 import jp.ac.mayoi.repository.interfaces.TravelingRepository
+import jp.ac.mayoi.wear.service.LocationService
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
@@ -31,7 +43,6 @@ class TravelingViewModel(
     }
 
     fun getNearSpot() {
-        // todo: repositoryから取得できる現在地のlat, lngをつかって、spotListStateを更新する
         val currentLat = currentLocation.latitude
         val currentLng = currentLocation.longitude
         previousState = spotListState
@@ -44,6 +55,61 @@ class TravelingViewModel(
             } catch (exception: Exception) {
                 Log.e("getNearSpot", "${exception.message}")
                 spotListState = LoadState.Error(spotListState.value, exception)
+            }
+        }
+    }
+
+    fun startLocationUpdate(
+        context: Context,
+    ) {
+        val intentFilter = IntentFilter().also {
+            it.addAction(locationIntentAction)
+        }
+        val intent = Intent(
+            context.applicationContext,
+            LocationService::class.java
+        ).also {
+            it.putExtra(locationPolingInterval, 10000L)
+        }
+
+        Log.d("LocationViewModel", "Starting LocationService")
+        context.applicationContext.startService(intent)
+        @SuppressLint("UnspecifiedRegisterReceiverFlag")
+        if (Build.VERSION.SDK_INT < 33) {
+            context.registerReceiver(
+                broadcastReceiver,
+                intentFilter
+            )
+        } else {
+            context.registerReceiver(
+                broadcastReceiver,
+                intentFilter,
+                RECEIVER_EXPORTED
+            )
+        }
+    }
+
+    fun stopLocationUpdate(
+        context: Context
+    ) {
+        Log.d("LocationViewModel", "Stopping LocationService")
+        context.applicationContext.stopService(
+            Intent(context.applicationContext, LocationService::class.java)
+        )
+    }
+
+    private val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val bundle = intent.extras ?: return
+            currentLocation.latitude =
+                bundle.getDouble(locationIntentLatitude, 0.0)
+            currentLocation.longitude =
+                bundle.getDouble(locationIntentLongitude, 0.0)
+
+            val maybeInitialLoad =
+                spotListState is LoadState.Loading && spotListState.value == null
+            if (maybeInitialLoad || spotListState is LoadState.Success) {
+                getNearSpot()
             }
         }
     }

--- a/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Strings.kt
+++ b/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Strings.kt
@@ -1,5 +1,1 @@
 package jp.ac.mayoi.wear.core.resource
-
-const val locationIntentAction = "MAIGO_COMPASS_LOCATION_BROADCAST"
-const val locationIntentLatitude = "Latitude"
-const val locationIntentLongitude = "Longitude"

--- a/wear/features/traveling/build.gradle.kts
+++ b/wear/features/traveling/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(project(":wear:service"))
     implementation(project(":wear:model"))
     implementation(project(":wear:core:resource"))
+    implementation(project(":common:resource"))
 
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.wear.tooling.preview)
@@ -50,7 +51,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.ui.tooling.preview)
-    implementation(project(":wear:core:resource"))
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingViewModel.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingViewModel.kt
@@ -20,9 +20,9 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import jp.ac.mayoi.common.model.RemoteSpotShrink
-import jp.ac.mayoi.wear.core.resource.locationIntentAction
-import jp.ac.mayoi.wear.core.resource.locationIntentLatitude
-import jp.ac.mayoi.wear.core.resource.locationIntentLongitude
+import jp.ac.mayoi.common.resource.locationIntentAction
+import jp.ac.mayoi.common.resource.locationIntentLatitude
+import jp.ac.mayoi.common.resource.locationIntentLongitude
 import jp.ac.mayoi.wear.model.RecommendSpot
 import jp.ac.mayoi.wear.repository.interfaces.CompassRepository
 import jp.ac.mayoi.wear.repository.interfaces.LocationRepository

--- a/wear/service/build.gradle.kts
+++ b/wear/service/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":wear:core:resource"))
+    implementation(project(":common:resource"))
 
     implementation(libs.bundles.wearComposeKit)
     implementation(libs.androidx.core.ktx)

--- a/wear/service/src/main/java/jp/ac/mayoi/wear/service/LocationService.kt
+++ b/wear/service/src/main/java/jp/ac/mayoi/wear/service/LocationService.kt
@@ -13,9 +13,9 @@ import com.google.android.gms.location.LocationListener
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
-import jp.ac.mayoi.wear.core.resource.locationIntentAction
-import jp.ac.mayoi.wear.core.resource.locationIntentLatitude
-import jp.ac.mayoi.wear.core.resource.locationIntentLongitude
+import jp.ac.mayoi.common.resource.locationIntentAction
+import jp.ac.mayoi.common.resource.locationIntentLatitude
+import jp.ac.mayoi.common.resource.locationIntentLongitude
 
 class LocationService : Service() {
 

--- a/wear/service/src/main/java/jp/ac/mayoi/wear/service/LocationService.kt
+++ b/wear/service/src/main/java/jp/ac/mayoi/wear/service/LocationService.kt
@@ -21,6 +21,7 @@ import jp.ac.mayoi.common.resource.locationPolingInterval
 class LocationService : Service() {
 
     private lateinit var locationClient: FusedLocationProviderClient
+    private lateinit var locationRequest: LocationRequest
 
     private val locationListener = LocationListener { p0 ->
         val currentLatitude = p0.latitude
@@ -47,7 +48,7 @@ class LocationService : Service() {
         ) {
             val polingInterval =
                 intent?.extras?.getLong(locationPolingInterval) ?: 1000L
-            val locationRequest = LocationRequest.Builder(
+            locationRequest = LocationRequest.Builder(
                 Priority.PRIORITY_BALANCED_POWER_ACCURACY,
                 polingInterval
             ).build()
@@ -62,6 +63,11 @@ class LocationService : Service() {
         }
 
         return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        locationClient.removeLocationUpdates(locationListener)
     }
 
     private fun broadcastLocation(latitude: Double, longitude: Double) {

--- a/wear/service/src/main/java/jp/ac/mayoi/wear/service/LocationService.kt
+++ b/wear/service/src/main/java/jp/ac/mayoi/wear/service/LocationService.kt
@@ -16,16 +16,11 @@ import com.google.android.gms.location.Priority
 import jp.ac.mayoi.common.resource.locationIntentAction
 import jp.ac.mayoi.common.resource.locationIntentLatitude
 import jp.ac.mayoi.common.resource.locationIntentLongitude
+import jp.ac.mayoi.common.resource.locationPolingInterval
 
 class LocationService : Service() {
 
     private lateinit var locationClient: FusedLocationProviderClient
-
-    private var locationRequest: LocationRequest =
-        LocationRequest.Builder(
-            Priority.PRIORITY_BALANCED_POWER_ACCURACY,
-            1000L
-        ).build()
 
     private val locationListener = LocationListener { p0 ->
         val currentLatitude = p0.latitude
@@ -37,7 +32,11 @@ class LocationService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int
+    ): Int {
 
         if (ActivityCompat.checkSelfPermission(
                 this, Manifest.permission.ACCESS_FINE_LOCATION
@@ -46,7 +45,15 @@ class LocationService : Service() {
                 this, Manifest.permission.ACCESS_COARSE_LOCATION
             ) == PackageManager.PERMISSION_GRANTED
         ) {
-            locationClient = LocationServices.getFusedLocationProviderClient(this)
+            val polingInterval =
+                intent?.extras?.getLong(locationPolingInterval) ?: 1000L
+            val locationRequest = LocationRequest.Builder(
+                Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                polingInterval
+            ).build()
+
+            locationClient =
+                LocationServices.getFusedLocationProviderClient(this)
             locationClient.requestLocationUpdates(
                 locationRequest,
                 locationListener,


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

旅行中に定期的におすすめスポットをAPIに訪ねに行く処理を書いた

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1/views/1?pane=issue&itemId=84822600

### 変更内容

<!-- 詳細な変更内容を書く -->

- `:wear:service:LocationService` を `:phone`でも共通して使うようにした
- 位置情報更新の頻度を変えられるようにした
- LocationServiceがServiceのライフサイクルを超えて位置情報を更新している問題を修正
- 旅行中画面でおすすめスポットをポーリングする処理を書いた

## テスト

<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

- 適当に移動してみて、現在の緯度経度が正常に更新されること
- 現在の緯度経度に基づいたおすすめスポットが取得できること