### PR TITLE
おすすめスポットと目的地画面を遷移できるようにする

### DIFF
--- a/wear/features/traveling/build.gradle.kts
+++ b/wear/features/traveling/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.wear.tooling.preview)
     implementation(libs.bundles.wearComposeKit)
+    implementation(libs.androidx.material3)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingRoot.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingRoot.kt
@@ -55,7 +55,6 @@ fun TravelingRoot(
     if (permitted) {
         // todo: あとでrykaの作ってる画面が入る
         TravelingScreen(
-            isHeadingDestination = true,
             travelingViewModel = viewModel
         )
     } else {

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -276,16 +276,14 @@ fun TriangleCore(
     val density = LocalDensity.current
     val rotationInRad = Math.toRadians(rotation.toDouble())
     with(density) {
-        val screenHeightInPx =
-            LocalConfiguration.current.screenHeightDp.dp.toPx()
-        val r =
-            screenHeightInPx / 2 - (12.dp + spacingHalf).toPx()
-        val offsetYInPx = r * sin(rotationInRad + Math.PI / 2f).toFloat()
+        val screenHeightInPx = LocalConfiguration.current.screenHeightDp.dp.toPx()
+        val r = screenHeightInPx / 2 - (12.dp + spacingHalf).toPx()
+        val offsetYInPx = r * -sin(rotationInRad + Math.PI / 2f).toFloat()
         val offsetXInPx = r * cos(rotationInRad + Math.PI / 2f).toFloat()
         Canvas(
             modifier = Modifier
                 .size(24.dp)
-                .offset(x = -offsetXInPx.toDp(), y = -offsetYInPx.toDp())
+                .offset(x = offsetXInPx.toDp(), y = offsetYInPx.toDp())
                 .clickable { onClick() }
         ) {
             val shrink = 16f
@@ -297,14 +295,16 @@ fun TriangleCore(
                 moveTo(size.width / 2f, size.height / 2f)
                 close()
             }
+
+            // DrawScopeはrotateの方向が時計回りなので、反時計回りに直す
+            val rotateInDrawScope = 360 - rotation
             rotate(
-                rotation,
+                degrees = rotateInDrawScope,
                 block = {
                     drawPath(
                         path = path,
                         color = color,
                     )
-                    // drawCircle(Color.Green, radius = 5f)
                 }
             )
         }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -2,7 +2,7 @@ package jp.ac.mayoi.wear.features.traveling
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -71,11 +70,7 @@ fun TravelingScreen(
                 travelingViewModel.focusing = recommendSpot
             }
         )
-        val distanceInMeter = if (isHeadingDestination) {
-            travelingViewModel.destination.distance
-        } else {
-            travelingViewModel.focusing.distance
-        }
+        val distanceInMeter = travelingViewModel.focusing.distance
         val distanceInKilo = (distanceInMeter / 100.0).roundToInt() / 10.0
         if (isHeadingDestination) {
             TextInCircle(
@@ -256,7 +251,6 @@ fun BestSpotDistanceText(distanceTexts: String) {
     }
 }
 
-
 // 目的地の方角を指す赤い三角形の実装
 @Composable
 fun RedTriangle(
@@ -266,27 +260,15 @@ fun RedTriangle(
 ) {
     Canvas(
         modifier = Modifier
-            .fillMaxSize()
             .rotate(destination.bearing.toFloat())
-            .pointerInput(Unit) {
-                detectTapGestures { offset ->
-                    // 三角形の頂点を定義
-                    val triangleVertices = listOf(
-                        Offset((size.width / 2).toFloat(), 1f), // 上頂点
-                        Offset(163f, 40f),         // 左下頂点
-                        Offset(220f, 40f)          // 右下頂点
-                    )
-                    if (isPointInTriangle(offset, triangleVertices)) {
-                        onClick()
-                    }
-                }
-            }
+            .size(100.dp)
+            .clickable { onClick() }
     ) {
         val path = Path().apply {
             // 三角形の頂点を設定
-            moveTo(size.width / 2, 1f)
-            lineTo(163f, 40f)
-            lineTo(220f, 40f)
+            moveTo(size.width / 2, size.height + 85)
+            lineTo(size.width / 2 - 25, size.height + 50)
+            lineTo(size.width / 2 + 25, size.height + 50)
             close()
         }
         drawPath(
@@ -304,56 +286,22 @@ fun BlueTriangle(
     isDarkBlueTriangleView: Boolean,
     recommendSpot: RecommendSpot
 ) {
-        Canvas(
-            modifier = Modifier
-                .fillMaxSize()
-                .rotate(recommendSpot.bearing.toFloat())
-                .pointerInput(Unit) {
-                    detectTapGestures { offset ->
-                        val triangleVertices = listOf(
-                            Offset(
-                                (size.width - 2).toFloat(),
-                                (size.height / 2).toFloat()
-                            ), // 上頂点
-                            Offset(340f, 163f),         // 左下頂点
-                            Offset(340f, 220f)          // 右下頂点
-                        )
-                        if (isPointInTriangle(offset, triangleVertices)) {
-                            onClick()
-                        }
-                    }
-                }
-
-        ) {
-            val path = Path().apply {
-                // 三角形の頂点を設定
-                moveTo(size.width - 2, size.height / 2)
-                lineTo(340f, 163f)
-                lineTo(340f, 220f)
-                close()
-            }
-            drawPath(
-                path,
-                color = if (isDarkBlueTriangleView) colorDarkBlueTriangle else colorBlueTriangle
-            )
+    Canvas(
+        modifier = Modifier
+            .rotate(recommendSpot.bearing.toFloat())
+            .size(100.dp)
+            .clickable { onClick() }
+    ) {
+        val path = Path().apply {
+            // 三角形の頂点を設定
+            moveTo(size.width + 85, size.height / 2)
+            lineTo(size.width + 50, size.height / 2 - 25)
+            lineTo(size.width + 50, size.height / 2 + 25)
+            close()
         }
+        drawPath(
+            path,
+            color = if (isDarkBlueTriangleView) colorDarkBlueTriangle else colorBlueTriangle
+        )
     }
-
-// 三角形を押してる時だけClick遷移するようにする
-fun isPointInTriangle(p: Offset, vertices: List<Offset>): Boolean {
-    if (vertices.size != 3) return false
-    val (v1, v2, v3) = vertices
-
-    fun sign(p1: Offset, p2: Offset, p3: Offset): Float {
-        return (p1.x - p3.x) * (p2.y - p3.y) - (p2.x - p3.x) * (p1.y - p3.y)
-    }
-
-    val d1 = sign(p, v1, v2)
-    val d2 = sign(p, v2, v3)
-    val d3 = sign(p, v3, v1)
-
-    val hasNeg = (d1 < 0) || (d2 < 0) || (d3 < 0)
-    val hasPos = (d1 > 0) || (d2 > 0) || (d3 > 0)
-
-    return !(hasNeg && hasPos)
 }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -296,7 +296,8 @@ fun TriangleCore(
                 close()
             }
 
-            // DrawScopeはrotateの方向が時計回りなので、反時計回りに直す
+            // DrawScopeはrotateの方向が時計回りなので、
+            // 反時計回りの回転角から時計回りの回転角に直す
             val rotateInDrawScope = 360 - rotation
             rotate(
                 degrees = rotateInDrawScope,

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -276,13 +276,16 @@ fun TriangleCore(
     val density = LocalDensity.current
     val rotationInRad = Math.toRadians(rotation.toDouble())
     with(density) {
+        val canvasSize = 24.dp
         val screenHeightInPx = LocalConfiguration.current.screenHeightDp.dp.toPx()
-        val r = screenHeightInPx / 2 - (12.dp + spacingHalf).toPx()
+        val r = screenHeightInPx / 2 - (canvasSize / 2 + spacingHalf).toPx()
+
+        // 画面の真上が現在の目線 → rotationが0 なので、位置合わせのために90°だけ座標系を回して計算する
         val offsetYInPx = r * -sin(rotationInRad + Math.PI / 2f).toFloat()
         val offsetXInPx = r * cos(rotationInRad + Math.PI / 2f).toFloat()
         Canvas(
             modifier = Modifier
-                .size(24.dp)
+                .size(canvasSize)
                 .offset(x = offsetXInPx.toDp(), y = offsetYInPx.toDp())
                 .clickable { onClick() }
         ) {
@@ -298,9 +301,9 @@ fun TriangleCore(
 
             // DrawScopeはrotateの方向が時計回りなので、
             // 反時計回りの回転角から時計回りの回転角に直す
-            val rotateInDrawScope = 360 - rotation
+            val rotationInDrawScope = 360 - rotation
             rotate(
-                degrees = rotateInDrawScope,
+                degrees = rotationInDrawScope,
                 block = {
                     drawPath(
                         path = path,

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -71,9 +71,10 @@ fun TravelingScreen(
             .fillMaxSize()
     ) {
         CommonTravelingScreen(
-            isDarkTriangleView = !isHeadingDestination,
+            isHeadingDestination = isHeadingDestination,
             destination = travelingViewModel.destination,
             recommendSpot = travelingViewModel.recommendSpot,
+            focusing = travelingViewModel.focusing,
             onRedTriangleClick = {
                 travelingViewModel.focusing = travelingViewModel.destination
             },
@@ -99,8 +100,9 @@ fun TravelingScreen(
 //旅行中画面の共通しているコードをまとめた
 @Composable
 fun CommonTravelingScreen(
-    isDarkTriangleView: Boolean,
+    isHeadingDestination: Boolean,
     destination: RecommendSpot,
+    focusing: RecommendSpot,
     recommendSpot: ImmutableList<RecommendSpot>,
     onRedTriangleClick: () -> Unit,
     onBlueTriangleClick: (RecommendSpot) -> Unit
@@ -112,15 +114,18 @@ fun CommonTravelingScreen(
     ) {
         // 青い三角形を無数に作成する場合
         for (recommend in recommendSpot) {
+            val isSameAsFocus =
+                recommend.lat == focusing.lat && recommend.lng == focusing.lng
+            val isLightBlueTriangle = !isHeadingDestination && isSameAsFocus
             BlueTriangle(
                 onClick = { onBlueTriangleClick(recommend) },
-                isDarkBlueTriangleView = !isDarkTriangleView,
+                isDarkBlueTriangleView = !isLightBlueTriangle,
                 recommendSpot = recommend
             )
         }
         RedTriangle(
             onClick = onRedTriangleClick,
-            isDarkRedTriangleView = isDarkTriangleView,
+            isDarkRedTriangleView = !isHeadingDestination,
             destination = destination
         )
     }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -370,6 +370,33 @@ private fun RedTrianglePreview() {
     }
 }
 
+// 左上に赤い矢印があるべき
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
+@Composable
+private fun RedTriangle45Preview() {
+    MaterialTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            HorizontalDivider()
+            VerticalDivider()
+            RedTriangle(
+                onClick = {},
+                isDarkRedTriangleView = false,
+                destination = RecommendSpot(
+                    lat = 0.0,
+                    lng = 0.0,
+                    comment = "",
+                    distance = 0.0,
+                    bearing = 45.0,
+                )
+            )
+        }
+    }
+}
+
+// 西南西に矢印がある
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 private fun BlueTrianglePreview() {
@@ -388,7 +415,7 @@ private fun BlueTrianglePreview() {
                     lng = 0.0,
                     comment = "",
                     distance = 0.0,
-                    bearing = 0.0
+                    bearing = 250.0
                 )
             )
         }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -46,11 +46,14 @@ import kotlin.math.roundToInt
 fun TravelingScreen(
     travelingViewModel: TravelingViewModel
 ) {
-    LaunchedEffect(travelingViewModel.focusing) {
+    LaunchedEffect(travelingViewModel) {
         travelingViewModel.updateLocation()
     }
     val isHeadingDestination by remember {
-        derivedStateOf { travelingViewModel.destination == travelingViewModel.focusing }
+        derivedStateOf {
+            travelingViewModel.destination.lat == travelingViewModel.focusing.lat &&
+                    travelingViewModel.destination.lng == travelingViewModel.focusing.lng
+        }
     }
     Box(
         contentAlignment = Alignment.Center,
@@ -68,15 +71,17 @@ fun TravelingScreen(
                 travelingViewModel.focusing = recommendSpot
             }
         )
+        val distanceInMeter = if (isHeadingDestination) {
+            travelingViewModel.destination.distance
+        } else {
+            travelingViewModel.focusing.distance
+        }
+        val distanceInKilo = (distanceInMeter / 100.0).roundToInt() / 10.0
         if (isHeadingDestination) {
-            val distanceInMeter = travelingViewModel.destination.distance
-            val distanceInKilo = (distanceInMeter / 100.0).roundToInt() / 10.0
             TextInCircle(
                 distanceText = "$distanceInKilo"
             )
         } else {
-            val focusingInMeter = travelingViewModel.focusing.distance
-            val distanceInKilo = (focusingInMeter / 100.0).roundToInt() / 10.0
             BestSpotTextInCircle(
                 text = travelingViewModel.focusing.comment,
                 distanceText = "$distanceInKilo",


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->
おすすめスポットと目的地画面を遷移できるようにする

### 関係するタスク
https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=83886317
<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->


### 変更内容
三角形を押すと「おすすめスポットの画面と目的地の画面」が遷移するようにつなげる
<!-- 詳細な変更内容を書く -->

<!-- 必要そうなら変更前後の画像を貼りましょう -->

| before | after |
|:------:|:-----:|
|        |       |