### PR TITLE
旅行中画面で、目的地までの距離が10000km越えから更新されないことがある

### DIFF
--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -82,8 +82,17 @@ fun TravelingScreen(
                 travelingViewModel.focusing = recommendSpot
             }
         )
-        val distanceInMeter = travelingViewModel.focusing.distance
+
+        val distanceInMeter = if (isHeadingDestination) {
+            travelingViewModel.destination.distance
+        } else {
+            val focusing = travelingViewModel.focusing
+            travelingViewModel.recommendSpot.find { spot ->
+                spot.lat == focusing.lat && spot.lng == focusing.lng
+            }?.distance ?: Double.POSITIVE_INFINITY
+        }
         val distanceInKilo = (distanceInMeter / 100.0).roundToInt() / 10.0
+
         if (isHeadingDestination) {
             TextInCircle(
                 distanceText = "$distanceInKilo"


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

Watch旅行中画面に遷移した際に、目的地までの距離が10000kmを超えた状態で表示されることがある。これは、位置情報が取得できるまで現在地が北緯0°、東経0°にあるためであるが、位置情報が取得できた後もこの距離が更新されないバグが存在する。  

原因はUIがfocusingから表示用の距離を取得していること。  
これにより、今回の修正対象の既知のバグだけでなく、いくら移動してもスポットを選択した時の残り距離から更新されないと言うバグも修正されることになる。  
isHeadingDestinationがtrueであろうとfalseであろうとfocusingのdistance値を参照してはいけない。

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=89491657

### 変更内容

<!-- 詳細な変更内容を書く -->

- 概要通り

## テスト

<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

- 旅行中画面に遷移したのち、何も操作せずとも距離の表示は正常値に戻るか