### PR TITLE
Watch旅行中画面のレスポンシブ対応を行なった

### DIFF
--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -172,15 +172,21 @@ private fun CenterCircle(
 // TravelingScreenの大きい円の中のテキストの実装
 @Composable
 private fun TextInCircle(distanceText: String) {
-    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp // As same as height
     val circleRadius = (screenWidth - 2 * (24.dp + 2.dp)) / 2
     CenterCircle(
         screenWidth = screenWidth,
         circleRadius = circleRadius,
     ) {
-        SmallTextCircle(
-            text = "目的地"
-        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(vertical = spacingTriple)
+        ) {
+            SmallTextCircle(
+                text = "目的地"
+            )
+        }
         DistanceText(
             distanceTexts = distanceText,
         )
@@ -197,7 +203,8 @@ private fun DistanceText(distanceTexts: String) {
             fontSize = 30.sp,
         )
         Text(
-            text = "km"
+            text = "km",
+            modifier = Modifier.padding(bottom = 3.dp, start = 6.dp)
         )
     }
 }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -3,9 +3,10 @@ package jp.ac.mayoi.wear.features.traveling
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
@@ -142,7 +143,7 @@ private fun CommonTravelingScreen(
 
 @Composable
 private fun CenterCircle(
-    content: @Composable (BoxScope.() -> Unit),
+    content: @Composable (ColumnScope.() -> Unit),
 ) {
     val screenWidth = with(LocalDensity.current) {
         LocalConfiguration.current.screenWidthDp.dp.toPx()
@@ -150,8 +151,9 @@ private fun CenterCircle(
     val radius = with(LocalDensity.current) {
         screenWidth - 2 * (24.dp.toPx() + 2.dp.toPx())
     } / 2
-    Box(
-        contentAlignment = Alignment.Center,
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
         content = content,
         modifier = Modifier
             .fillMaxSize()

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,7 +25,6 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
@@ -140,26 +140,36 @@ private fun CommonTravelingScreen(
     }
 }
 
-// TravelingScreenの大きい円の中のテキストの実装
 @Composable
-private fun TextInCircle(distanceText: String) {
-    val paint = Paint().apply {
-        strokeWidth = 2f
-        isAntiAlias = true
+private fun CenterCircle(
+    content: @Composable (BoxScope.() -> Unit),
+) {
+    val screenWidth = with(LocalDensity.current) {
+        LocalConfiguration.current.screenWidthDp.dp.toPx()
     }
+    val radius = with(LocalDensity.current) {
+        screenWidth - 2 * (24.dp.toPx() + 2.dp.toPx())
+    } / 2
     Box(
         contentAlignment = Alignment.Center,
+        content = content,
         modifier = Modifier
             .fillMaxSize()
             .drawBehind {
                 drawCircle(
                     color = colorButtonTextPrimary,
-                    radius = 140f,
-                    center = Offset(190f, 190f),
-                    style = Stroke(paint.strokeWidth)
+                    radius = radius,
+                    center = Offset(screenWidth / 2, screenWidth / 2),
+                    style = Stroke(width = 2f)
                 )
             }
-    ) {
+    )
+}
+
+// TravelingScreenの大きい円の中のテキストの実装
+@Composable
+private fun TextInCircle(distanceText: String) {
+    CenterCircle {
         SmallTextCircle(
             text = "目的地"
         )
@@ -218,23 +228,7 @@ private fun BestSpotTextInCircle(
     distanceText: String,
     text: String,
 ) {
-    val paint = Paint().apply {
-        strokeWidth = 2f
-        isAntiAlias = true
-    }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .fillMaxSize()
-            .drawBehind {
-                drawCircle(
-                    color = colorButtonTextPrimary,
-                    radius = 140f,
-                    center = Offset(190f, 190f),
-                    style = Stroke(paint.strokeWidth)
-                )
-            }
-    ) {
+    CenterCircle {
         SmallTextCircle(
             text = "おすすめスポット"
         )
@@ -432,5 +426,23 @@ private fun BlueTrianglePreview() {
                 )
             )
         }
+    }
+}
+
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
+@Composable
+private fun TextInCirclePreview() {
+    MaterialTheme {
+        TextInCircle("12.3")
+    }
+}
+
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
+@Composable
+private fun BestSpotInCirclePreview() {
+    MaterialTheme {
+        BestSpotTextInCircle("12.3", "Preview")
     }
 }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -3,7 +3,6 @@ package jp.ac.mayoi.wear.features.traveling
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -18,7 +17,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -29,6 +30,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
@@ -153,7 +155,6 @@ private fun CenterCircle(
     } / 2
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
         content = content,
         modifier = Modifier
             .fillMaxSize()
@@ -165,6 +166,7 @@ private fun CenterCircle(
                     style = Stroke(width = 2f)
                 )
             }
+            .padding(26.dp)
     )
 }
 
@@ -183,18 +185,16 @@ private fun TextInCircle(distanceText: String) {
 
 @Composable
 private fun DistanceText(distanceTexts: String) {
-    Column {
-        Row(
-            verticalAlignment = Alignment.Bottom
-        ) {
-            Text(
-                text = distanceTexts,
-                fontSize = 30.sp,
-            )
-            Text(
-                text = "km"
-            )
-        }
+    Row(
+        verticalAlignment = Alignment.Bottom
+    ) {
+        Text(
+            text = distanceTexts,
+            fontSize = 30.sp,
+        )
+        Text(
+            text = "km"
+        )
     }
 }
 
@@ -203,23 +203,29 @@ private fun SmallTextCircle(
     text: String,
     circleColor: Color = colorButtonTextPrimary,
 ) {
+    var textWidth by remember { mutableFloatStateOf(0f) }
+    var textHeight by remember { mutableFloatStateOf(0f) }
     Box(
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.padding(vertical = 4.dp)
     ) {
         Text(
             text = text,
-            style = TextStyle(fontSize = 6.sp),
+            style = TextStyle(fontSize = 8.sp),
             modifier = Modifier
+                .onGloballyPositioned { layoutCoordinates ->
+                    textHeight = layoutCoordinates.size.height.toFloat()
+                    textWidth = layoutCoordinates.size.width.toFloat()
+                }
                 .drawBehind {
                     drawRoundRect(
                         color = circleColor,
                         cornerRadius = CornerRadius(32f),
-                        size = Size(size.width + 10, size.height / 10),
+                        size = Size(textWidth + 24f, textHeight + 8f),
                         style = Stroke(width = 2f),
-                        topLeft = Offset(-4f, 0f)
+                        topLeft = Offset(-12f, -4f)
                     )
                 }
-                .padding(bottom = 90.dp)
         )
     }
 }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -262,44 +262,45 @@ private fun BestSpotTextInCircle(
         screenWidth = screenWidth,
         circleRadius = circleRadius,
     ) {
-        SmallTextCircle(
-            text = "おすすめスポット"
-        )
-        Image(
-            painter = painterResource(id = R.drawable.smail),
-            contentDescription = "Smail Image",
+        Box(
             modifier = Modifier
-                .padding(bottom = spacingTriple)
-                .size(35.dp)
-        )
-        Text(
-            text = text,
-            fontSize = 12.sp,
-            modifier = Modifier
-                .padding(top = 35.dp)
-        )
-        BestSpotDistanceText(
-            distanceTexts = distanceText
-        )
-    }
-}
+                .align(Alignment.TopCenter)
+                .padding(vertical = spacingDouble)
+        ) {
+            SmallTextCircle(
+                text = "おすすめスポット"
+            )
+        }
 
-@Composable
-private fun BestSpotDistanceText(distanceTexts: String) {
-    Row(
-        verticalAlignment = Alignment.Bottom,
-        modifier = Modifier
-            .padding(top = 80.dp)
-    ) {
-        Text(
-            text = distanceTexts,
-            fontSize = 25.sp,
-        )
-        Text(
-            text = "km",
-            fontSize = 10.sp,
-            modifier = Modifier.padding(bottom = 2.dp, start = 6.dp)
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.smail),
+                contentDescription = "Smail Image",
+                modifier = Modifier
+                    .size(35.dp)
+            )
+
+            Spacer(modifier = Modifier.size(spacingHalf))
+
+            Text(
+                text = text,
+                fontSize = 12.sp,
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = spacingSingle + spacingHalf)
+        ) {
+            DistanceText(
+                distanceTexts = distanceText,
+                fontSize = 25.sp
+            )
+        }
     }
 }
 
@@ -467,7 +468,9 @@ private fun BlueTrianglePreview() {
 @Composable
 private fun TextInCirclePreview() {
     MaterialTheme {
-        TextInCircle("12.3")
+        TextInCircle(
+            distanceText = "12.3"
+        )
     }
 }
 
@@ -476,6 +479,9 @@ private fun TextInCirclePreview() {
 @Composable
 private fun BestSpotInCirclePreview() {
     MaterialTheme {
-        BestSpotTextInCircle("12.3", "Preview")
+        BestSpotTextInCircle(
+            distanceText = "12.3",
+            text = "あ".repeat(10)
+        )
     }
 }

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -4,8 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
@@ -36,8 +35,10 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.times
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.tooling.preview.devices.WearDevices
@@ -145,24 +146,22 @@ private fun CommonTravelingScreen(
 
 @Composable
 private fun CenterCircle(
-    content: @Composable (ColumnScope.() -> Unit),
+    circleRadius: Dp,
+    screenWidth: Dp,
+    content: @Composable (BoxScope.() -> Unit),
 ) {
-    val screenWidth = with(LocalDensity.current) {
-        LocalConfiguration.current.screenWidthDp.dp.toPx()
-    }
-    val radius = with(LocalDensity.current) {
-        screenWidth - 2 * (24.dp.toPx() + 2.dp.toPx())
-    } / 2
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
+    val widthInPx = with(LocalDensity.current) { screenWidth.toPx() }
+    val radiusInPx = with(LocalDensity.current) { circleRadius.toPx() }
+    Box(
+        contentAlignment = Alignment.Center,
         content = content,
         modifier = Modifier
             .fillMaxSize()
             .drawBehind {
                 drawCircle(
                     color = colorButtonTextPrimary,
-                    radius = radius,
-                    center = Offset(screenWidth / 2, screenWidth / 2),
+                    radius = radiusInPx,
+                    center = Offset(widthInPx / 2, widthInPx / 2),
                     style = Stroke(width = 2f)
                 )
             }
@@ -173,7 +172,12 @@ private fun CenterCircle(
 // TravelingScreenの大きい円の中のテキストの実装
 @Composable
 private fun TextInCircle(distanceText: String) {
-    CenterCircle {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val circleRadius = (screenWidth - 2 * (24.dp + 2.dp)) / 2
+    CenterCircle(
+        screenWidth = screenWidth,
+        circleRadius = circleRadius,
+    ) {
         SmallTextCircle(
             text = "目的地"
         )
@@ -236,7 +240,12 @@ private fun BestSpotTextInCircle(
     distanceText: String,
     text: String,
 ) {
-    CenterCircle {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val circleRadius = (screenWidth - 2 * (24.dp + 2.dp)) / 2
+    CenterCircle(
+        screenWidth = screenWidth,
+        circleRadius = circleRadius,
+    ) {
         SmallTextCircle(
             text = "おすすめスポット"
         )

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -34,8 +36,10 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.times
@@ -47,7 +51,9 @@ import jp.ac.mayoi.wear.core.resource.colorButtonTextPrimary
 import jp.ac.mayoi.wear.core.resource.colorDarkBlueTriangle
 import jp.ac.mayoi.wear.core.resource.colorDarkRedTriangle
 import jp.ac.mayoi.wear.core.resource.colorRedTriangle
+import jp.ac.mayoi.wear.core.resource.spacingDouble
 import jp.ac.mayoi.wear.core.resource.spacingHalf
+import jp.ac.mayoi.wear.core.resource.spacingSingle
 import jp.ac.mayoi.wear.core.resource.spacingTriple
 import jp.ac.mayoi.wear.model.RecommendSpot
 import kotlinx.collections.immutable.ImmutableList
@@ -194,13 +200,16 @@ private fun TextInCircle(distanceText: String) {
 }
 
 @Composable
-private fun DistanceText(distanceTexts: String) {
+private fun DistanceText(
+    distanceTexts: String,
+    fontSize: TextUnit = 30.sp,
+) {
     Row(
         verticalAlignment = Alignment.Bottom
     ) {
         Text(
             text = distanceTexts,
-            fontSize = 30.sp,
+            fontSize = fontSize,
         )
         Text(
             text = "km",


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

今までWatch旅行中画面はpaddingなどを用いてアラインメントされていた。そのため、Watch 2 と 3 のデバイス間の解像度差異を吸収することができていなかった。  
このPRでは、paddingによる位置調整をやめ、ColumnやRowを用いたアラインメントを行うように変更した。

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=89503791

### 変更内容

<!-- 詳細な変更内容を書く -->

- 共通化すべきコンポーネントを共通化した
- レイアウトの中で、paddingを用いて位置合わせを行なっているコンポーネントをLayoutによる位置合わせに変更した
- Previewを行えるように関数の切り分けを行い、Previewを作成した。

## テスト

<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

- デバイス間で表示に大きな差が発生しないようになっているか

## 画像
<!-- 実装した画面のスクリーンショットを貼りましょう -->
<!-- 必要そうなら変更前後の画像を貼りましょう -->

上が Watch 2。下が Watch 3。  
方位角の違いは単にセンサーの差異なので、気にしないで大丈夫

| before | after |
|:------:|:-----:|
|    ![watch2_before](https://github.com/user-attachments/assets/b42e9bfe-5bb1-43f6-bf9c-2b11c3d9279a)    |    ![watch2_after_retake](https://github.com/user-attachments/assets/3c16e408-db49-48ed-8bd3-ef699d9f6efa)   |
|    ![watch3_before](https://github.com/user-attachments/assets/0a52d54f-412d-42ad-b893-bc18751103e4)    |   ![watch3_after](https://github.com/user-attachments/assets/f839c435-1500-4467-a7e8-36924b952b74)    |
