### PR TITLE
PhoneからWatchに旅行開始時の目的地を送信する機能を付与した

### DIFF
--- a/common/model/src/main/java/jp/ac/mayoi/common/model/Destination.kt
+++ b/common/model/src/main/java/jp/ac/mayoi/common/model/Destination.kt
@@ -1,0 +1,9 @@
+package jp.ac.mayoi.common.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Destination(
+    val lat: Double,
+    val lng: Double,
+)

--- a/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
+++ b/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
@@ -6,3 +6,4 @@ const val locationIntentLongitude = "Longitude"
 const val locationPolingInterval = "Location_Poling_Interval"
 
 const val dataLayerRecommendSpotPath = "/recommend_spots_data"
+const val commonDataLayerDestinationPath = "/destination_data"

--- a/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
+++ b/common/resource/src/main/java/jp/ac/mayoi/common/resource/Strings.kt
@@ -7,3 +7,4 @@ const val locationPolingInterval = "Location_Poling_Interval"
 
 const val dataLayerRecommendSpotPath = "/recommend_spots_data"
 const val commonDataLayerDestinationPath = "/destination_data"
+const val commonDataLayerFinishTravelingPath = "/travel_finish"

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -21,6 +22,7 @@ import jp.ac.mayoi.onboarding.OnboardingViewModel
 import jp.ac.mayoi.ranking.RankingScreen
 import jp.ac.mayoi.traveling.ParentScreen
 import jp.ac.mayoi.traveling.TravelingViewModel
+import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -35,10 +37,18 @@ fun PhoneNavHost(
     ) {
         composable<OnboardingNavigation> {
             val onboardingViewModel: OnboardingViewModel = koinViewModel()
+            val coroutineScope = rememberCoroutineScope()
             OnboardingScreen(
                 onCameraPositionChanged = onboardingViewModel::onCameraChanged,
                 onDecideClicked = {
-                    navController.navigate(TravelingNavigation)
+                    coroutineScope.launch {
+                        onboardingViewModel
+                            .onBeforeNavigateToTravelingScreen()
+                            .await()
+                            .onSuccess {
+                                navController.navigate(TravelingNavigation)
+                            }
+                    }
                 },
                 onCurrentPositionClicked = {},
             )

--- a/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
+++ b/phone/app/src/main/java/jp/ac/mayoi/maigocompass/NavHost.kt
@@ -68,10 +68,18 @@ fun PhoneNavHost(
         }
         composable<TravelingNavigation> {
             val travelingViewModel: TravelingViewModel = koinViewModel()
+            val coroutineScope = rememberCoroutineScope()
             ParentScreen(
                 viewModel = travelingViewModel,
                 onTripCancelButtonClick = {
-                    navController.popBackStack()
+                    coroutineScope.launch {
+                        travelingViewModel
+                            .notifyFinishTravel()
+                            .await()
+                            .onSuccess {
+                                navController.popBackStack()
+                            }
+                    }
                 },
                 onRetryButtonClick = {
                     travelingViewModel.getNearSpot()

--- a/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
+++ b/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
@@ -137,7 +137,7 @@ abstract class BaseApplication : Application() {
     }
 
     private val viewModelKoinModule = module {
-        viewModel { OnboardingViewModel() }
+        viewModel { OnboardingViewModel(get(), get()) }
         viewModel { TravelingViewModel(get(), get(), get()) }
         viewModel { RankingViewModel(get()) }
     }

--- a/phone/core/resource/src/main/java/jp/ac/mayoi/core/resource/Strings.kt
+++ b/phone/core/resource/src/main/java/jp/ac/mayoi/core/resource/Strings.kt
@@ -1,5 +1,7 @@
 package jp.ac.mayoi.core.resource
 
 import jp.ac.mayoi.common.resource.commonDataLayerDestinationPath
+import jp.ac.mayoi.common.resource.commonDataLayerFinishTravelingPath
 
 const val dataLayerDestinationPath = commonDataLayerDestinationPath
+const val dataLayerFinishTravelingPath = commonDataLayerFinishTravelingPath

--- a/phone/core/resource/src/main/java/jp/ac/mayoi/core/resource/Strings.kt
+++ b/phone/core/resource/src/main/java/jp/ac/mayoi/core/resource/Strings.kt
@@ -1,2 +1,5 @@
 package jp.ac.mayoi.core.resource
 
+import jp.ac.mayoi.common.resource.commonDataLayerDestinationPath
+
+const val dataLayerDestinationPath = commonDataLayerDestinationPath

--- a/phone/features/onboarding/build.gradle.kts
+++ b/phone/features/onboarding/build.gradle.kts
@@ -30,6 +30,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":common:model"))
     implementation(project(":phone:core:util"))
     implementation(project(":phone:core:resource"))
     implementation(platform(libs.androidx.compose.bom))
@@ -39,6 +40,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.material)
     implementation(libs.bundles.maps)
+    implementation(libs.play.services.wearable)
+    implementation(libs.kotlinx.coroutine.play.services)
+    implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
+++ b/phone/features/onboarding/src/main/java/jp/ac/mayoi/onboarding/OnboaringViewModel.kt
@@ -1,16 +1,67 @@
 package jp.ac.mayoi.onboarding
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.MessageClient
+import jp.ac.mayoi.common.model.Destination
+import jp.ac.mayoi.core.resource.dataLayerDestinationPath
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.tasks.await
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
-class OnboardingViewModel : ViewModel() {
-    var destination: LatLng by mutableStateOf(LatLng(0.0, 0.0))
-        private set
+class OnboardingViewModel(
+    private val messageClient: MessageClient,
+    private val capabilityClient: CapabilityClient,
+) : ViewModel() {
+    private var destination: LatLng by mutableStateOf(LatLng(0.0, 0.0))
 
     fun onCameraChanged(newPosition: LatLng) {
         destination = newPosition
+    }
+
+    fun onBeforeNavigateToTravelingScreen(): Deferred<Result<Unit>> {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val payload = Destination(
+            lat = destination.latitude,
+            lng = destination.longitude,
+        )
+        val jsonString = Json.encodeToString(payload)
+
+        return scope.async {
+            try {
+                val nodes = capabilityClient
+                    .getCapability("wear", CapabilityClient.FILTER_REACHABLE)
+                    .await()
+                    .nodes
+                nodes.map { node ->
+                    async {
+                        messageClient.sendMessage(
+                            node.id,
+                            dataLayerDestinationPath,
+                            jsonString.toByteArray(Charsets.UTF_8)
+                        ).await()
+                    }
+                }.awaitAll()
+                Result.success(Unit)
+            } catch (e: CancellationException) {
+                Log.d("OnboardingViewModel", "Canceled")
+                Result.failure(e)
+            } catch (e: Exception) {
+                Log.d("OnboardingViewModel", "Failed to send message")
+                Result.failure(e)
+            }
+        }
     }
 }

--- a/wear/app/src/main/java/jp/ac/mayoi/maigocompass/presentation/MaigoNavigation.kt
+++ b/wear/app/src/main/java/jp/ac/mayoi/maigocompass/presentation/MaigoNavigation.kt
@@ -6,11 +6,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import jp.ac.mayoi.common.model.Destination
 import jp.ac.mayoi.wear.core.navigation.SettingsNavigation
 import jp.ac.mayoi.wear.core.navigation.TripNavigation
 import jp.ac.mayoi.wear.core.navigation.WatchWaitNavigation
 import jp.ac.mayoi.wear.features.traveling.TravelingRoot
 import jp.ac.mayoi.wear.features.traveling.TravelingViewModel
+import jp.ac.mayoi.wear.features.waiting.WaitingScreenViewModel
 import jp.ac.mayoi.wear.features.waiting.WaitingSwipe
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -40,20 +42,25 @@ fun WearNavigation(
             )
         }
         composable<WatchWaitNavigation> {
+            val waitingViewModel: WaitingScreenViewModel = koinViewModel {
+                val onDestinationReceivedListener: (Destination) -> Unit = {
+                    navController.navigate(
+                        TripNavigation(
+                            destinationLat = it.lat,
+                            destinationLng = it.lng,
+                        )
+                    )
+                }
+                parametersOf(onDestinationReceivedListener)
+            }
+
             WaitingSwipe(
+                viewModel = waitingViewModel,
                 onSettingButtonClick = {
                     navController.navigate(
                         SettingsNavigation
                     )
                 },
-                onReceiveDestinationData = { lat, lng ->
-                    val route = TripNavigation(
-                        destinationLat = lat,
-                        destinationLng = lng,
-                    )
-
-                    navController.navigate(route)
-                }
             )
         }
         composable<SettingsNavigation> {

--- a/wear/app/src/main/java/jp/ac/mayoi/maigocompass/presentation/MaigoNavigation.kt
+++ b/wear/app/src/main/java/jp/ac/mayoi/maigocompass/presentation/MaigoNavigation.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import jp.ac.mayoi.wear.core.navigation.SettingsNavigation
 import jp.ac.mayoi.wear.core.navigation.TripNavigation
 import jp.ac.mayoi.wear.core.navigation.WatchWaitNavigation
@@ -23,18 +24,13 @@ fun WearNavigation(
         navController = navController,
         startDestination = WatchWaitNavigation,
     ) {
-        composable<TripNavigation> {
+        composable<TripNavigation> { backStackEntry ->
+            val route: TripNavigation = backStackEntry.toRoute()
             val travelingViewModel: TravelingViewModel = koinViewModel {
-                // 本当はここをNavArgsで持ってくる
-                // 1. Waitingでスマホから目的地情報を受け取る
-                // 2. 目的地情報を使って遷移
-                // 3. ここで目的地情報をViewModelに詰めてViewを作成
-                // の流れ
                 val destination = run {
                     Location(null).also {
-                        // とりあえず五稜郭にしてある
-                        it.latitude = 41.797653393691476
-                        it.longitude = 140.7550099479477
+                        it.latitude = route.destinationLat
+                        it.longitude = route.destinationLng
                     }
                 }
                 parametersOf(destination)
@@ -49,6 +45,14 @@ fun WearNavigation(
                     navController.navigate(
                         SettingsNavigation
                     )
+                },
+                onReceiveDestinationData = { lat, lng ->
+                    val route = TripNavigation(
+                        destinationLat = lat,
+                        destinationLng = lng,
+                    )
+
+                    navController.navigate(route)
                 }
             )
         }

--- a/wear/app/src/main/java/jp/ac/mayoi/maigocompass/presentation/MaigoNavigation.kt
+++ b/wear/app/src/main/java/jp/ac/mayoi/maigocompass/presentation/MaigoNavigation.kt
@@ -39,6 +39,11 @@ fun WearNavigation(
             }
             TravelingRoot(
                 viewModel = travelingViewModel,
+                onFinishTraveling = {
+                    if (!navController.popBackStack()) {
+                        navController.navigate(WatchWaitNavigation)
+                    }
+                }
             )
         }
         composable<WatchWaitNavigation> {

--- a/wear/core/application/build.gradle.kts
+++ b/wear/core/application/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(project(":wear:repository:interfaces"))
     implementation(project(":wear:repository:implementations"))
     implementation(project(":wear:features:traveling"))
+    implementation(project(":wear:features:waiting"))
 
     implementation(libs.bundles.wearComposeKit)
     implementation(platform(libs.koin.bom))

--- a/wear/core/application/src/main/java/jp/ac/mayoi/wear/core/application/BaseApplication.kt
+++ b/wear/core/application/src/main/java/jp/ac/mayoi/wear/core/application/BaseApplication.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.MessageClient
 import com.google.android.gms.wearable.Wearable
 import jp.ac.mayoi.wear.features.traveling.TravelingViewModel
+import jp.ac.mayoi.wear.features.waiting.WaitingScreenViewModel
 import jp.ac.mayoi.wear.repository.implementations.CompassRepositoryImpl
 import jp.ac.mayoi.wear.repository.implementations.LocationRepositoryImpl
 import jp.ac.mayoi.wear.repository.implementations.TravelingRepositoryImpl
@@ -57,6 +58,9 @@ abstract class BaseApplication : Application() {
     }
 
     private val viewModelKoinModule = module {
+        viewModel { parameters ->
+            WaitingScreenViewModel(get(), onDestinationReceivedListener = parameters.get())
+        }
         viewModel { parameters ->
             TravelingViewModel(get(), get(), get(), get(), _destination = parameters.get())
         }

--- a/wear/core/navigation/src/main/java/jp/ac/mayoi/wear/core/navigation/WearNavigation.kt
+++ b/wear/core/navigation/src/main/java/jp/ac/mayoi/wear/core/navigation/WearNavigation.kt
@@ -3,7 +3,10 @@ package jp.ac.mayoi.wear.core.navigation
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object TripNavigation
+data class TripNavigation(
+    val destinationLat: Double,
+    val destinationLng: Double,
+)
 
 @Serializable
 data object WatchWaitNavigation

--- a/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Strings.kt
+++ b/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Strings.kt
@@ -1,5 +1,7 @@
 package jp.ac.mayoi.wear.core.resource
 
 import jp.ac.mayoi.common.resource.commonDataLayerDestinationPath
+import jp.ac.mayoi.common.resource.commonDataLayerFinishTravelingPath
 
 const val dataLayerDestinationPath = commonDataLayerDestinationPath
+const val dataLayerFinishTravelingPath = commonDataLayerFinishTravelingPath

--- a/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Strings.kt
+++ b/wear/core/resource/src/main/java/jp/ac/mayoi/wear/core/resource/Strings.kt
@@ -1,1 +1,5 @@
 package jp.ac.mayoi.wear.core.resource
+
+import jp.ac.mayoi.common.resource.commonDataLayerDestinationPath
+
+const val dataLayerDestinationPath = commonDataLayerDestinationPath

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingRoot.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingRoot.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,6 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.tooling.preview.devices.WearDevices
@@ -36,7 +38,8 @@ import jp.ac.mayoi.wear.core.resource.textStyleBody
 
 @Composable
 fun TravelingRoot(
-    viewModel: TravelingViewModel
+    viewModel: TravelingViewModel,
+    onFinishTraveling: () -> Unit,
 ) {
     val context = LocalContext.current
     var permitted by remember { mutableStateOf(checkTravelingPermission(context)) }
@@ -49,6 +52,15 @@ fun TravelingRoot(
             if (permitted) {
                 viewModel.stopSensor(context)
             }
+        }
+    }
+
+    val finishTravelingNotification by
+    viewModel.finishTravelingNotification.collectAsStateWithLifecycle()
+
+    LaunchedEffect(finishTravelingNotification) {
+        if (finishTravelingNotification) {
+            onFinishTraveling()
         }
     }
 

--- a/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingViewModel.kt
+++ b/wear/features/traveling/src/main/java/jp/ac/mayoi/wear/features/traveling/TravelingViewModel.kt
@@ -69,6 +69,8 @@ class TravelingViewModel(
         )
     var focusing: RecommendSpot by mutableStateOf(destination)
 
+    val finishTravelingNotification = travelingRepository.finishTravelingNotification
+
     private val rotationVectorSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
 
     init {

--- a/wear/features/waiting/build.gradle.kts
+++ b/wear/features/waiting/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":common:model"))
     implementation(project(":wear:core:resource"))
 
     implementation(libs.androidx.wear.tooling.preview)
@@ -51,6 +52,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreenViewModel.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingScreenViewModel.kt
@@ -1,11 +1,19 @@
 package jp.ac.mayoi.wear.features.waiting
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.google.android.gms.wearable.MessageClient
+import jp.ac.mayoi.common.model.Destination
+import jp.ac.mayoi.wear.core.resource.dataLayerDestinationPath
+import kotlinx.serialization.json.Json
 
-class WaitingScreenViewModel : ViewModel() {
+class WaitingScreenViewModel(
+    private val messageClient: MessageClient,
+    private val onDestinationReceivedListener: (Destination) -> Unit,
+) : ViewModel() {
     var isButtonView: Boolean by mutableStateOf(true)
         private set
 
@@ -13,4 +21,28 @@ class WaitingScreenViewModel : ViewModel() {
         isButtonView = false
     }
 
+    fun startReceivingMessage() {
+        messageClient.addListener(messageClientListener)
+    }
+
+    fun stopReceivingMessage() {
+        messageClient.removeListener(messageClientListener)
+    }
+
+    private val messageClientListener = MessageClient.OnMessageReceivedListener { p0 ->
+        when (p0.path) {
+            dataLayerDestinationPath -> {
+                val data = p0.data.toString(Charsets.UTF_8)
+                try {
+                    val destination: Destination = Json.decodeFromString(data)
+                    Log.d("TravelingRepository", "Destination data received: $destination")
+                    onDestinationReceivedListener(destination)
+                } catch (e: Exception) {
+                    Log.d("TravelingRepository", "Failed to parse destination from message.\n$data")
+                }
+            }
+
+            else -> Unit
+        }
+    }
 }

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingSwipe.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingSwipe.kt
@@ -16,26 +16,28 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import jp.ac.mayoi.wear.core.resource.colorButtonTextPrimary
 import jp.ac.mayoi.wear.core.resource.colorTextCaption
 import jp.ac.mayoi.wear.core.resource.spacingHalf
 
 @Composable
 fun WaitingSwipe(
+    viewModel: WaitingScreenViewModel,
     onSettingButtonClick: () -> Unit,
-    onReceiveDestinationData: (lat: Double, lng: Double) -> Unit,
-    viewModel: WaitingScreenViewModel = viewModel()
 ) {
+    LifecycleResumeEffect(Unit) {
+        viewModel.startReceivingMessage()
+        onPauseOrDispose {
+            viewModel.stopReceivingMessage()
+        }
+    }
+
     WaitingSwipe(
         isButtonView = viewModel.isButtonView,
         onSettingButtonClick = onSettingButtonClick,
         onSetDestinationButtonClick = {
             viewModel.onSetDestinationButtonClick()
-            onReceiveDestinationData(
-                41.797653393691476,
-                140.7550099479477,
-            )
         },
     )
 }

--- a/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingSwipe.kt
+++ b/wear/features/waiting/src/main/java/jp/ac/mayoi/wear/features/waiting/WaitingSwipe.kt
@@ -24,12 +24,19 @@ import jp.ac.mayoi.wear.core.resource.spacingHalf
 @Composable
 fun WaitingSwipe(
     onSettingButtonClick: () -> Unit,
+    onReceiveDestinationData: (lat: Double, lng: Double) -> Unit,
     viewModel: WaitingScreenViewModel = viewModel()
 ) {
     WaitingSwipe(
         isButtonView = viewModel.isButtonView,
         onSettingButtonClick = onSettingButtonClick,
-        onSetDestinationButtonClick = viewModel::onSetDestinationButtonClick,
+        onSetDestinationButtonClick = {
+            viewModel.onSetDestinationButtonClick()
+            onReceiveDestinationData(
+                41.797653393691476,
+                140.7550099479477,
+            )
+        },
     )
 }
 

--- a/wear/repository/implementations/build.gradle.kts
+++ b/wear/repository/implementations/build.gradle.kts
@@ -39,6 +39,7 @@ android {
 dependencies {
     implementation(project(":common:model"))
     implementation(project(":common:resource"))
+    implementation(project(":wear:core:resource"))
     implementation(project(":wear:repository:interfaces"))
 
     implementation(libs.play.services.wearable)

--- a/wear/repository/implementations/src/main/java/jp/ac/mayoi/wear/repository/implementations/TravelingRepositoryImpl.kt
+++ b/wear/repository/implementations/src/main/java/jp/ac/mayoi/wear/repository/implementations/TravelingRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.google.android.gms.wearable.MessageClient
 import jp.ac.mayoi.common.model.RemoteSpotShrinkList
 import jp.ac.mayoi.common.resource.dataLayerRecommendSpotPath
+import jp.ac.mayoi.wear.core.resource.dataLayerFinishTravelingPath
 import jp.ac.mayoi.wear.repository.interfaces.TravelingRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +19,10 @@ class TravelingRepositoryImpl(
     private val _recommendSpot: MutableStateFlow<RemoteSpotShrinkList> =
         MutableStateFlow(initialValue)
     override val recommendSpot: StateFlow<RemoteSpotShrinkList> = _recommendSpot.asStateFlow()
+
+    private val _finishTravelingNotification: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val finishTravelingNotification: StateFlow<Boolean> =
+        _finishTravelingNotification.asStateFlow()
 
     override fun startReceiveSpots() {
         messageClient.addListener(messageClientListener)
@@ -43,6 +48,12 @@ class TravelingRepositoryImpl(
                     }
                 } catch (e: Exception) {
                     Log.d("TravelingRepository", "Failed to parse recommend spots message.\n$data")
+                }
+            }
+            dataLayerFinishTravelingPath -> {
+                Log.d("TravelingRepository", "Received finish message.")
+                runBlocking {
+                    _finishTravelingNotification.emit(true)
                 }
             }
         }

--- a/wear/repository/interfaces/src/main/java/jp/ac/mayoi/wear/repository/interfaces/TravelingRepository.kt
+++ b/wear/repository/interfaces/src/main/java/jp/ac/mayoi/wear/repository/interfaces/TravelingRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 abstract class TravelingRepository {
     abstract val recommendSpot: StateFlow<RemoteSpotShrinkList>
+    abstract val finishTravelingNotification: StateFlow<Boolean>
     abstract fun startReceiveSpots()
     abstract fun stopReceiveSpots()
 }


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

- PhoneからWatchに目的地を送信する機能を実装した
  - まだ不完全なので、両方のActivityがTopに載っている必要がある
  - 今後可能なタイミングでIntentやServiceを用いた送信処理に移行する

### 関係するタスク

<!-- 関係するタスクを迷子コンパスタスクボードからリストアップする -->
<!-- もしこのPRがmargeされればcloseしてもよいissueが存在する場合は close #n (nは当該のPRの数字) と書く -->

- https://github.com/orgs/mayoi-design/projects/1?pane=issue&itemId=90321120

## テスト

<!-- 実装した機能/変更が正常であるか確認するためのテスト項目を書く -->

- OnboardingScreenから目的地を決定した時、Watch側で正常にTripNavigationに遷移できるか
- 画面遷移前のブロッキングは正常に行われているか
  - 状態は競合していないか