### PR TITLE
円グラフの中で選択したエントリが拡大するようにした

### DIFF
--- a/phone/features/memory/src/main/java/jp/ac/mayoi/memory/graph/MemoryGraph.kt
+++ b/phone/features/memory/src/main/java/jp/ac/mayoi/memory/graph/MemoryGraph.kt
@@ -22,7 +22,7 @@ fun MemoryGraph(
     selectedEntry: Int?,
     onChartEntrySelected: (Int?) -> Unit,
 ) {
-    val chartBoxSize = 550.dp
+    val chartBoxSize = 400.dp
     Box {
         MemoryPieChart(
             model = model,

--- a/phone/features/memory/src/main/java/jp/ac/mayoi/memory/graph/MemoryPieChart.kt
+++ b/phone/features/memory/src/main/java/jp/ac/mayoi/memory/graph/MemoryPieChart.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.HorizontalDivider
@@ -15,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import jp.ac.mayoi.core.resource.MaigoCompassTheme
@@ -30,7 +33,10 @@ import jp.ac.mayoi.phone.model.PieChartModel
 import kotlin.math.atan2
 import kotlin.math.min
 
-private val arcOuterPadding = 64.dp
+private val arcOuterPaddingAsPx
+    @Composable get() = with(LocalDensity.current) { 64.dp.toPx() }
+private val arcOuterExpandWidthAsPx
+    @Composable get() = with(LocalDensity.current) { 24.dp.toPx() }
 
 @Composable
 internal fun MemoryPieChart(
@@ -50,88 +56,103 @@ internal fun MemoryPieChart(
             }
     }
 
-    Canvas(
+    BoxWithConstraints(
         modifier = modifier
-            .pointerInput(Unit) {
-                detectTapGestures { p ->
-                    val center = Offset(size.width.toFloat() / 2, size.height.toFloat() / 2)
-                    val tapPoint = Offset(x = p.x - center.x, y = center.y - p.y)
-                    val r = tapPoint.getDistance()
-
-                    // 回転角の回る方向を反時計回りから時計回りにして、-90°スタートにする
-                    val rawThetaInDeg =
-                        360f - Math.toDegrees(atan2(tapPoint.y, tapPoint.x).toDouble()).mod(360f)
-                    val theta = if (rawThetaInDeg > 270) {
-                        rawThetaInDeg - 360f
-                    } else {
-                        rawThetaInDeg
-                    }
-
-                    // fixme: rかouterR, innerRが微妙にズレてる気がする？
-                    val d = min(size.width, size.height)
-                    val normalOuterR = (d - arcOuterPadding.toPx()) / 2
-                    val differenceRate = ((d - 300.dp.toPx()) / 300.dp.toPx() + 1f)
-                    val innerR = normalOuterR - 48.dp.toPx() * differenceRate
-                    for (i in angleRangeForEach.indices) {
-                        val begin = angleRangeForEach[i].first
-                        val end = begin + angleRangeForEach[i].second
-
-                        // 円グラフの特性上270°を跨いで区間が存在することがないので簡単な判定で良い
-                        if (begin <= theta && theta < end) {
-                            Log.d(
-                                "MemoryPieChart",
-                                "Theta Condition Satisfied. begin: $begin, end: $end, theta: $theta, innerR: $innerR, normalOuterR: $normalOuterR, r: $r"
-                            )
-                            if (innerR <= r && r < normalOuterR) {
-                                onEntrySelected(i)
-                                Log.d("MemoryPieChart", "entry $i selected.")
-                                return@detectTapGestures
-                            }
-                        }
-                    }
-                    onEntrySelected(null)
-                    Log.d(
-                        "MemoryPieChart",
-                        "Nothing Selected. RawTapPos: $p, Tap pos: $tapPoint, theta: $theta r: $r"
-                    )
-                }
-            }
     ) {
-        val d = min(size.width, size.height)
-        val arcSize = Size(
-            width = d - arcOuterPadding.toPx(),
-            height = d - arcOuterPadding.toPx()
-        )
-        val arcOffset = Offset(
-            x = (size.width - arcSize.width) / 2,
-            y = (size.height - arcSize.height) / 2
-        )
-
-        for (it in 0..<model.entries.size) {
-            drawArc(
-                color = model.entries[it].arcColor,
-                startAngle = angleRangeForEach[it].first,
-                sweepAngle = angleRangeForEach[it].second,
-                useCenter = true,
-                topLeft = arcOffset,
-                size = arcSize
-            )
+        val density = LocalDensity.current
+        val boxSize = with(density) {
+            Size(constraints.maxWidth.toDp().toPx(), constraints.maxHeight.toDp().toPx())
         }
+        val diameter = min(boxSize.width, boxSize.height)
+        val arcSize = Size(
+            width = diameter - arcOuterPaddingAsPx,
+            height = diameter - arcOuterPaddingAsPx,
+        )
+        val expandedArcSize = Size(
+            width = diameter - arcOuterPaddingAsPx + arcOuterExpandWidthAsPx,
+            height = diameter - arcOuterPaddingAsPx + arcOuterExpandWidthAsPx,
+        )
 
         // このUIは高さ300dpのPreviewで作成している
         // 高さが300dpから変わるとグラフの色のついた部分の幅が太くなったり狭くなったりする
         // これを防ぐために、今のmin(width, height)が300dpからどれほど離れているのかを計算し、
         // 色部分の幅48dpにかけることでレスポンシブに描画できるようになる
-        val differenceRate = ((d - 300.dp.toPx()) / 300.dp.toPx() + 1f)
-        val centerOuterPadding =
-            48.dp.toPx() * differenceRate + arcOuterPadding.toPx()
-        val centerRadius = (d - centerOuterPadding) / 2
-        val centerArcOffset = Offset(x = size.width / 2, y = size.height / 2)
-        drawCircle(
-            color = colorBackgroundPrimary,
-            radius = centerRadius,
-            center = centerArcOffset
-        )
+        val scale = with(density) { ((diameter - 300.dp.toPx()) / 300.dp.toPx() + 1f) }
+        val centerOuterPadding = with(density) { 48.dp.toPx() * scale + arcOuterPaddingAsPx }
+        val centerRadius = (diameter - centerOuterPadding) / 2
+        val centerArcOffset = Offset(x = boxSize.width / 2, y = boxSize.height / 2)
+
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(selectedEntry) {
+                    detectTapGestures { p ->
+                        val center = Offset(size.width.toFloat() / 2, size.height.toFloat() / 2)
+                        val tapPoint = Offset(x = p.x - center.x, y = center.y - p.y)
+                        val r = tapPoint.getDistance()
+
+                        // 回転角の回る方向を反時計回りから時計回りにして、-90°スタートにする
+                        val rawThetaInDeg =
+                            360f - Math.toDegrees(atan2(tapPoint.y, tapPoint.x).toDouble())
+                                .mod(360f)
+                        val theta = if (rawThetaInDeg > 270) {
+                            rawThetaInDeg - 360f
+                        } else {
+                            rawThetaInDeg
+                        }
+
+                        for (i in angleRangeForEach.indices) {
+                            val begin = angleRangeForEach[i].first
+                            val end = begin + angleRangeForEach[i].second
+
+                            // 円グラフの特性上270°を跨いで区間が存在することがないので簡単な判定で良い
+                            if (begin <= theta && theta < end) {
+                                // fixme: rかouterR, innerRが微妙にズレてる気がする？
+                                val outerR =
+                                    if (i == selectedEntry) expandedArcSize.width / 2 else arcSize.width / 2
+                                Log.d(
+                                    "MemoryPieChart",
+                                    "Theta Condition Satisfied. i:$i theta: $theta, r: $r"
+                                )
+
+                                if (centerRadius <= r && r < outerR) {
+                                    onEntrySelected(i)
+                                    Log.d("MemoryPieChart", "entry $i selected.")
+                                    return@detectTapGestures
+                                }
+                            }
+                        }
+                        onEntrySelected(null)
+                        Log.d(
+                            "MemoryPieChart",
+                            "Nothing Selected. RawTapPos: $p, Tap pos: $tapPoint, theta: $theta r: $r"
+                        )
+                    }
+                }
+        ) {
+            for (it in 0..<model.entries.size) {
+                val itSize = if (it == selectedEntry) expandedArcSize else arcSize
+                val arcOffset = Offset(
+                    x = (boxSize.width - itSize.width) / 2,
+                    y = (boxSize.height - itSize.height) / 2,
+                )
+
+                drawArc(
+                    color = model.entries[it].arcColor,
+                    startAngle = angleRangeForEach[it].first,
+                    sweepAngle = angleRangeForEach[it].second,
+                    useCenter = true,
+                    topLeft = arcOffset,
+                    size = itSize,
+                )
+            }
+
+            drawCircle(
+                color = colorBackgroundPrimary,
+                radius = centerRadius,
+                center = centerArcOffset
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

おもいで画面の円グラフで、選択されたエントリに応じて、対応するエントリのタップ可能領域が拡大し、色付きの縁も大きくなるようにした。
