### PR TITLE
サーバーとやり取りする文字列enumをKotlinのenumに変換する処理を実装

### DIFF
--- a/phone/model/src/main/java/jp/ac/mayoi/phone/model/enums/ServiceArea.kt
+++ b/phone/model/src/main/java/jp/ac/mayoi/phone/model/enums/ServiceArea.kt
@@ -1,0 +1,59 @@
+package jp.ac.mayoi.phone.model.enums
+
+import jp.ac.mayoi.phone.model.interfaces.StringEnum
+import jp.ac.mayoi.phone.model.interfaces.StringEnumAdapter
+
+object ServiceAreaAdapter : StringEnumAdapter<ServiceAreaAdapter.ServiceArea>() {
+    override val default: ServiceArea
+        get() = ServiceArea.UNKNOWN
+
+    override fun fromRemote(remoteToken: String): ServiceArea =
+        enumValues<ServiceArea>().find { it.remoteToken == remoteToken } ?: default
+
+    enum class ServiceArea : StringEnum<ServiceArea> {
+        HAKODATE_STA {
+            override val localToken: String
+                get() = localPrefix + "HAKODATE_STATION"
+            override val remoteToken: String
+                get() = "ekimae"
+        },
+        HAKODATE_BAY {
+            override val localToken: String
+                get() = localPrefix + "HAKODATE_BAY"
+            override val remoteToken: String
+                get() = "bay"
+        },
+        MT_HAKODATE {
+            override val localToken: String
+                get() = localPrefix + "MT_HAKODATE"
+            override val remoteToken: String
+                get() = "hakodateyama"
+        },
+        GORYOKAKU {
+            override val localToken: String
+                get() = localPrefix + "GORYOKAKU"
+            override val remoteToken: String
+                get() = "goryokaku"
+        },
+        YUNOKAWA {
+            override val localToken: String
+                get() = localPrefix + "YUNOKAWA"
+            override val remoteToken: String
+                get() = "yunokawa"
+        },
+        MIHARA {
+            override val localToken: String
+                get() = localPrefix + "HAKODATE_MIHARA"
+            override val remoteToken: String
+                get() = "mihara"
+        },
+        UNKNOWN {
+            override val localToken: String
+                get() = "UNKNOWN"
+            override val remoteToken: String
+                get() = "UNKNOWN"
+        };
+
+        internal val localPrefix = "MAIGO_COMPASS_SERVICE_AREA_"
+    }
+}

--- a/phone/model/src/main/java/jp/ac/mayoi/phone/model/interfaces/StringEnum.kt
+++ b/phone/model/src/main/java/jp/ac/mayoi/phone/model/interfaces/StringEnum.kt
@@ -1,0 +1,11 @@
+package jp.ac.mayoi.phone.model.interfaces
+
+interface StringEnum<T : Enum<T>> {
+    val remoteToken: String
+    val localToken: String
+}
+
+abstract class StringEnumAdapter<T : Enum<T>> {
+    abstract val default: T
+    abstract fun fromRemote(remoteToken: String): T
+}

--- a/phone/model/src/test/kotlin/jp/ac/mayoi/phone/model/enums/ServiceAreaParseTest.kt
+++ b/phone/model/src/test/kotlin/jp/ac/mayoi/phone/model/enums/ServiceAreaParseTest.kt
@@ -1,0 +1,23 @@
+package jp.ac.mayoi.phone.model.enums
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ServiceAreaParseTest {
+
+    @Test
+    fun can_parse_hakodate_st() {
+        val remote = "ekimae"
+        val actual = ServiceAreaAdapter.fromRemote(remote)
+
+        assertEquals(ServiceAreaAdapter.ServiceArea.HAKODATE_STA, actual)
+    }
+
+    @Test
+    fun invalid_remote_token() {
+        val remote = "invalid"
+        val actual = ServiceAreaAdapter.fromRemote(remote)
+
+        assertEquals(ServiceAreaAdapter.ServiceArea.UNKNOWN, actual)
+    }
+}

--- a/phone/model/src/test/kotlin/jp/ac/mayoi/phone/model/enums/ServiceAreaParseTest.kt
+++ b/phone/model/src/test/kotlin/jp/ac/mayoi/phone/model/enums/ServiceAreaParseTest.kt
@@ -5,12 +5,17 @@ import org.junit.Test
 
 class ServiceAreaParseTest {
 
+    // 何かenumを一項目追加すると落ちるテスト
+    // サーバー側でenumを追加した際は、ここで文字列の確認を行う
+    // remoteに入れる文字列は必ずswaggerの返り値からコピペすること
     @Test
-    fun can_parse_hakodate_st() {
-        val remote = "ekimae"
-        val actual = ServiceAreaAdapter.fromRemote(remote)
+    fun can_parse_server_area() {
+        val remote = listOf("ekimae", "bay", "hakodateyama", "goryokaku", "yunokawa", "mihara")
+        val actual = remote.map { ServiceAreaAdapter.fromRemote(it) }
 
-        assertEquals(ServiceAreaAdapter.ServiceArea.HAKODATE_STA, actual)
+        val expected = ServiceAreaAdapter.ServiceArea.entries.toTypedArray()
+            .filter { it.remoteToken != "UNKNOWN" }
+        assertEquals(expected, actual)
     }
 
     @Test


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

サーバーとクライアントではuniqueな文字列を用いたenumをやり取りする。Http通信上ではただのstringであるが、クライアント側ではKotlinのenumとして扱うことによるコード上のメリットも存在する。

そこで、文字列からKotlin enumへの変換処理を行うような `StringEnumAdapter` と `StringEnum` を実装した。

