### PR TITLE
TravelingRepository.getAreaByCoordinateを実装

### DIFF
--- a/phone/app/src/development/java/jp/ac/mayoi/maigocompass/mock/DevelopmentTravelingRepository.kt
+++ b/phone/app/src/development/java/jp/ac/mayoi/maigocompass/mock/DevelopmentTravelingRepository.kt
@@ -1,11 +1,13 @@
 package jp.ac.mayoi.maigocompass.mock
 
 import jp.ac.mayoi.phone.model.LocalSpot
+import jp.ac.mayoi.phone.model.enums.ServiceAreaAdapter
 import jp.ac.mayoi.repository.interfaces.TravelingRepository
 import kotlinx.coroutines.delay
 
 class DevelopmentTravelingRepository : TravelingRepository {
     private var nearSpotsGetCount = 0
+    private var getAreaCount = 0
 
     override suspend fun getNearSpots(lat: Double, lng: Double): List<LocalSpot> {
         delay(2000)
@@ -27,5 +29,17 @@ class DevelopmentTravelingRepository : TravelingRepository {
                 spotId = "",
             )
         }
+    }
+
+    override suspend fun getAreaByCoordinate(
+        lat: Double,
+        lng: Double,
+    ): ServiceAreaAdapter.ServiceArea {
+        delay(1000)
+
+        val areas = ServiceAreaAdapter.ServiceArea.entries.toTypedArray()
+        val res = areas[getAreaCount % areas.size]
+        getAreaCount += 1
+        return res
     }
 }

--- a/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
+++ b/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
@@ -135,7 +135,7 @@ abstract class BaseApplication : Application() {
 
     private val repositoryKoinModule = module {
         factory<RankingRepository> { RankingRepositoryImpl(get()) }
-        factory<TravelingRepository> { TravelingRepositoryImpl(get()) }
+        factory<TravelingRepository> { TravelingRepositoryImpl(get(), get()) }
     }
 
     private val viewModelKoinModule = module {

--- a/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
+++ b/phone/core/application/src/main/java/jp/ac/mayoi/core/application/BaseApplication.kt
@@ -16,6 +16,7 @@ import jp.ac.mayoi.service.interfaces.HealthService
 import jp.ac.mayoi.service.interfaces.ImageService
 import jp.ac.mayoi.service.interfaces.RankingService
 import jp.ac.mayoi.service.interfaces.SpotService
+import jp.ac.mayoi.service.interfaces.TravelService
 import jp.ac.mayoi.traveling.TravelingViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -129,6 +130,7 @@ abstract class BaseApplication : Application() {
         factory<RankingService> { retrofit.create(RankingService::class.java) }
         factory<SpotService> { retrofit.create(SpotService::class.java) }
         factory<ImageService> { retrofit.create(ImageService::class.java) }
+        factory<TravelService> { retrofit.create(TravelService::class.java) }
     }
 
     private val repositoryKoinModule = module {

--- a/phone/repository/implementations/src/main/java/jp/ac/mayoi/repository/implementations/TravelingRepositoryImpl.kt
+++ b/phone/repository/implementations/src/main/java/jp/ac/mayoi/repository/implementations/TravelingRepositoryImpl.kt
@@ -1,14 +1,25 @@
 package jp.ac.mayoi.repository.implementations
 
 import jp.ac.mayoi.phone.model.LocalSpot
+import jp.ac.mayoi.phone.model.enums.ServiceAreaAdapter
 import jp.ac.mayoi.repository.interfaces.TravelingRepository
 import jp.ac.mayoi.service.interfaces.SpotService
+import jp.ac.mayoi.service.interfaces.TravelService
 
 class TravelingRepositoryImpl(
     private val spotService: SpotService,
+    private val travelService: TravelService,
 ) : TravelingRepository {
     override suspend fun getNearSpots(lat: Double, lng: Double): List<LocalSpot> =
         spotService.getSpotByLatLng(lat, lng).map { spot ->
             LocalSpot(spot)
         }
+
+    override suspend fun getAreaByCoordinate(
+        lat: Double,
+        lng: Double,
+    ): ServiceAreaAdapter.ServiceArea {
+        val remote = travelService.getAreaByCoordinate(lat, lng)
+        return ServiceAreaAdapter.fromRemote(remote.areaId)
+    }
 }

--- a/phone/repository/interfaces/src/main/java/jp/ac/mayoi/repository/interfaces/TravelingRepository.kt
+++ b/phone/repository/interfaces/src/main/java/jp/ac/mayoi/repository/interfaces/TravelingRepository.kt
@@ -1,10 +1,16 @@
 package jp.ac.mayoi.repository.interfaces
 
 import jp.ac.mayoi.phone.model.LocalSpot
+import jp.ac.mayoi.phone.model.enums.ServiceAreaAdapter
 
 interface TravelingRepository {
     suspend fun getNearSpots(
         lat: Double,
         lng: Double,
     ): List<LocalSpot>
+
+    suspend fun getAreaByCoordinate(
+        lat: Double,
+        lng: Double,
+    ): ServiceAreaAdapter.ServiceArea
 }

--- a/phone/service/interfaces/src/main/java/jp/ac/mayoi/service/interfaces/TravelService.kt
+++ b/phone/service/interfaces/src/main/java/jp/ac/mayoi/service/interfaces/TravelService.kt
@@ -1,0 +1,14 @@
+package jp.ac.mayoi.service.interfaces
+
+import jp.ac.mayoi.phone.model.RemoteRankingArea
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface TravelService {
+
+    @GET("travel/area")
+    suspend fun getAreaByCoordinate(
+        @Query("lat") lat: Double,
+        @Query("lng") lng: Double,
+    ): RemoteRankingArea
+}


### PR DESCRIPTION
## 概要

<!-- ざっくりと変更内容や必要な情報を書く -->

旅行終了時に旅行を終了したエリアを判定するために使用する (予定)  
取得したエリア情報を用いて、おもいで画面で利用するデータを更新する